### PR TITLE
작성 중 큐 비우기 — draft 22개 정리 (draft 0)

### DIFF
--- a/src/content/memo/190.md
+++ b/src/content/memo/190.md
@@ -1,7 +1,7 @@
 ---
 type: note
 tags: ['datadog']
-status: draft
+status: archive
 ctime: 2022-06-18
 mtime: 2024-03-22
 ---

--- a/src/content/memo/223.md
+++ b/src/content/memo/223.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['mobx', 'async', 'action']
-status: draft
+status: release
 ctime: 2022-10-16
 mtime: 2024-03-22
 ---

--- a/src/content/memo/267.md
+++ b/src/content/memo/267.md
@@ -1,7 +1,7 @@
 ---
 type: note
 tags: ['prompt', 'llm']
-status: draft
+status: release
 ctime: 2023-05-01
 mtime: 2026-07-27
 ---

--- a/src/content/memo/274.md
+++ b/src/content/memo/274.md
@@ -1,7 +1,7 @@
 ---
 type: note
 tags: ['terms', '버스-팩터']
-status: draft
+status: release
 ctime: 2023-05-28
 mtime: 2026-07-27
 ---

--- a/src/content/memo/276.md
+++ b/src/content/memo/276.md
@@ -1,17 +1,20 @@
 ---
 type: snippet
 tags: ['datadog', 'sourcemaps']
-status: draft
+status: release
 ctime: 2023-06-09
-mtime: 2024-03-22
+mtime: 2026-08-02
 ---
 
-```
-SERVICE=wantedspace-dashboard
-MINIFIED_PATH_PREFIX=https://dashboard.wantedspace.ai/static/js
-VERSION=$(git log --pretty=format:'%h' -n 1);
+올린 뒤 배포물에서 지운다 — Datadog은 이미 받았고 브라우저에는 노출되지 않는다.
 
-yarn datadog-ci sourcemaps upload ./build --service $SERVICE --minified-path-prefix $MINIFIED_PATH_PREFIX --release-version $VERSION
+```sh
+VERSION=$(git log --pretty=format:'%h' -n 1)
+
+yarn datadog-ci sourcemaps upload ./build \
+  --service "$SERVICE" \
+  --minified-path-prefix "$MINIFIED_PATH_PREFIX" \
+  --release-version "$VERSION"
 
 rm ./build/static/js/*.map
 ```

--- a/src/content/memo/277.md
+++ b/src/content/memo/277.md
@@ -1,22 +1,18 @@
 ---
 type: snippet
 tags: ['openapi', 'zod']
-status: draft
+status: release
 ctime: 2023-06-09
-mtime: 2024-03-22
+mtime: 2026-08-02
 ---
+
+Swagger 2.0 스펙은 바로 못 먹인다. OpenAPI 3으로 바꾼 다음 zod 클라이언트를 만든다.
 
 ```json
 {
   "scripts": {
-    "zod": "openapi-zod-client -a \"./spec.yaml\" -o \"./spec.ts\"",
-    "convert": "swagger2openapi ./spec.json -o ./spec.yaml"
-  },
-  "dependencies": {
-    "openapi-zod-client": "^1.6.4",
-    "orval": "^6.15.0",
-    "prettier": "^2.8.8",
-    "swagger2openapi": "^7.0.8"
+    "convert": "swagger2openapi ./spec.json -o ./spec.yaml",
+    "zod": "openapi-zod-client -a \"./spec.yaml\" -o \"./spec.ts\""
   }
 }
 ```

--- a/src/content/memo/278.md
+++ b/src/content/memo/278.md
@@ -1,24 +1,18 @@
 ---
 type: snippet
 tags: ['zod', 'error']
-status: draft
+status: release
 ctime: 2023-06-13
-mtime: 2024-03-22
+mtime: 2026-08-02
 ---
 
-https://github.com/ecyrbe/zodios/issues/402
-https://www.jacobparis.com/content/type-safe-env
+zodios는 `ZodError`를 `ZodiosError.cause`에 담아 던진다 — `instanceof z.ZodError`로는 안 잡힌다.
 
----
-
-```
-if (err instanceof z.ZodError) {}
-```
-
-```
-if(err instanceof ZodiosError) {
-   if (err.cause instanceof ZodError) {
-      console.log(fromZodError(err.cause).toString())
-   }
+```ts
+if (err instanceof ZodiosError && err.cause instanceof ZodError) {
+  console.log(fromZodError(err.cause).toString())
 }
 ```
+
+- [isErrorFromAlias not finding errors when uri have undefined params · Issue #402 · ecyrbe/zodios](https://github.com/ecyrbe/zodios/issues/402)
+- https://www.jacobparis.com/content/type-safe-env

--- a/src/content/memo/292.md
+++ b/src/content/memo/292.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['webpack', 'esm']
-status: draft
+status: release
 ctime: 2023-08-28
 mtime: 2024-03-22
 ---

--- a/src/content/memo/294.md
+++ b/src/content/memo/294.md
@@ -1,10 +1,12 @@
 ---
 type: snippet
 tags: ['proxy', 'debug']
-status: draft
+status: release
 ctime: 2023-09-04
-mtime: 2024-03-22
+mtime: 2026-08-02
 ---
+
+요청 본문은 한 번만 읽을 수 있다. 누가 미리 읽었는지는 읽기 메서드를 Proxy 로 감싸서 찾는다.
 
 ```js
 const bodyReadingMethods = ['arrayBuffer', 'blob', 'formData', 'text', 'json']
@@ -17,7 +19,6 @@ bodyReadingMethods.forEach((methodName) => {
     },
   })
 })
-
 ```
 
 https://redd.one/blog/debugging-like-a-pro-xy

--- a/src/content/memo/374.md
+++ b/src/content/memo/374.md
@@ -1,47 +1,20 @@
 ---
 type: snippet
 tags: ['test', 'jest']
-status: draft
+status: release
 ctime: 2025-01-18
-mtime: 2025-01-18
+mtime: 2026-08-02
 ---
 
 https://www.emgoto.com/jest-partial-match/
 
-`objectContaining`, `arrayContaining`, 및 `toHaveBeenCalledWith`를 사용하기
+`objectContaining`·`arrayContaining` 은 `toEqual`·`toHaveBeenCalledWith` 안에 중첩해서 쓴다.
 
 ```typescript
-test('objectContaining으로 특정 키/값 매칭', () => {
-  const receivedObject = {
-    id: 1,
-    name: 'Alice',
-    age: 30,
-    city: 'Seoul',
-  }
-
-  expect(receivedObject).toEqual(
-    expect.objectContaining({
-      name: 'Alice',
-      city: 'Seoul',
-    })
-  )
-})
-
-test('arrayContaining으로 특정 값 배열 매칭', () => {
-  const receivedArray = [1, 2, 3, 4, 5]
-
-  expect(receivedArray).toEqual(expect.arrayContaining([2, 4]))
-})
-
-test('toHaveBeenCalledWith을 사용한 부분 매칭', () => {
+test('호출 인자 부분 매칭', () => {
   const mockFunction = jest.fn()
 
-  // Mock 함수 호출
-  mockFunction({
-    id: 1,
-    name: 'Alice',
-    tags: ['developer', 'designer'],
-  })
+  mockFunction({ id: 1, name: 'Alice', tags: ['developer', 'designer'] })
 
   expect(mockFunction).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -51,11 +24,10 @@ test('toHaveBeenCalledWith을 사용한 부분 매칭', () => {
   )
 })
 
-test('arrayContaining + objectContaining으로 복합 매칭', () => {
+test('배열 안 객체 부분 매칭', () => {
   const receivedArray = [
     { id: 1, name: 'Alice' },
     { id: 2, name: 'Bob' },
-    { id: 3, name: 'Charlie' },
   ]
 
   expect(receivedArray).toEqual(

--- a/src/content/memo/375.md
+++ b/src/content/memo/375.md
@@ -1,35 +1,20 @@
 ---
 type: snippet
 tags: ['active-element', 'dom', 'focus']
-status: draft
+status: release
 ctime: 2025-01-18
-mtime: 2025-01-18
+mtime: 2026-08-02
 ---
 
-`document.activeElement` - 현재 포커스된 요소 반환
+`document.activeElement` — 현재 포커스된 요소
 
 ```javascript
-// 포커스된 입력 필드 확인
 const el = document.activeElement
+
 if (el.tagName === 'INPUT') console.log(el.value)
 
 // 모달 열릴 때 닫기 버튼으로 포커스 이동
 document.querySelector('.modal .close-button').focus()
-
-// 키보드 내비게이션 추적
-document.addEventListener('keydown', (e) => {
-  if (e.key === 'Tab') console.log('Focused:', document.activeElement)
-})
-
-// Enter 키 처리 분기
-document.addEventListener('keydown', (e) => {
-  if (e.key !== 'Enter') return
-  const el = document.activeElement
-  if (el.tagName === 'BUTTON') el.click()
-  else if (el.tagName === 'INPUT') console.log('Submit:', el.value)
-})
 ```
-
-활용: 포커스 관리, 키보드 내비게이션, 접근성 강화, 폼 검증 피드백
 
 - [MDN - document.activeElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement)

--- a/src/content/memo/377.md
+++ b/src/content/memo/377.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['github-actions', 'monorepo']
-status: draft
+status: release
 ctime: 2025-01-19
 mtime: 2025-01-19
 ---

--- a/src/content/memo/410.md
+++ b/src/content/memo/410.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['next', 'next-sitemap']
-status: draft
+status: release
 ctime: 2025-02-14
 mtime: 2025-02-14
 ---

--- a/src/content/memo/462.md
+++ b/src/content/memo/462.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['typescript', 'verbatim-module-syntax']
-status: draft
+status: release
 ctime: 2025-03-04
 mtime: 2025-03-04
 ---

--- a/src/content/memo/481.md
+++ b/src/content/memo/481.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['typescript']
-status: draft
+status: release
 ctime: 2025-03-05
 mtime: 2025-03-05
 ---

--- a/src/content/memo/482.md
+++ b/src/content/memo/482.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['typescript', 'union']
-status: draft
+status: release
 ctime: 2025-03-05
 mtime: 2025-03-05
 ---

--- a/src/content/memo/483.md
+++ b/src/content/memo/483.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['typescript', 'Exclude']
-status: draft
+status: release
 ctime: 2025-03-05
 mtime: 2025-03-05
 ---

--- a/src/content/memo/484.md
+++ b/src/content/memo/484.md
@@ -1,12 +1,12 @@
 ---
 type: snippet
 tags: ['store', 'redux', 'pattern']
-status: draft
+status: release
 ctime: 2025-03-05
-mtime: 2025-03-05
+mtime: 2026-08-02
 ---
 
-Redux 스타일 Store 직접 구현 - `getState`, `subscribe`, `dispatch` 패턴
+Redux 스타일 Store 직접 구현
 
 ```ts
 type Reducer<S, A> = (state: S, action: A) => S

--- a/src/content/memo/493.md
+++ b/src/content/memo/493.md
@@ -1,7 +1,7 @@
 ---
 type: snippet
 tags: ['astro', 'vercel']
-status: draft
+status: archive
 ctime: 2025-06-24
 mtime: 2025-06-24
 ---

--- a/src/content/memo/541.md
+++ b/src/content/memo/541.md
@@ -2,7 +2,7 @@
 type: note
 tags:
   ['inspect-webkit', 'ios', 'debug', 'safari', 'webview', 'mobile', 'tooling']
-status: draft
+status: release
 ctime: 2026-05-25
 mtime: 2026-06-02
 ---

--- a/src/content/memo/71.md
+++ b/src/content/memo/71.md
@@ -1,10 +1,9 @@
 ---
 type: note
 tags: ['redux', 'debug']
-status: draft
+status: release
 ctime: 2022-04-09
-mtime: 2024-03-22
+mtime: 2026-08-02
 ---
 
-redux 사용하다가 trace가 필요하면 [해당설정](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Features/Trace.md)을 활성화 시켜주면 된다.
-메모리릭 가능성이 있기 때문에...우회 한다면 약간 무식한 방법이긴 하지만 거기다 싶은 지점에서 [console.trace()](https://developer.mozilla.org/ko/docs/Web/API/Console/trace)를
+redux 에서 trace 가 필요하면 redux-devtools 의 [trace 설정](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Features/Trace.md)을 켠다. 다만 메모리 릭 가능성이 있어서 상시로 켜두긴 어렵다 — 우회한다면 무식하지만 의심 지점에 [`console.trace()`](https://developer.mozilla.org/ko/docs/Web/API/Console/trace)를 직접 넣는다.

--- a/src/content/memo/95.md
+++ b/src/content/memo/95.md
@@ -1,7 +1,7 @@
 ---
 type: note
 tags: ['tools', 'filezilla', 'ftp']
-status: draft
+status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
 ---


### PR DESCRIPTION
[#21](https://github.com/cbcruk/cbcruk.github.io/pull/21)에서 "저장만 해둔 것"을 걷어내고 남은 `draft` 22개를 끝까지 처리한다. **작성 중 큐 22 → 0** (공개 274 → 294).

세 묶음으로 나눠 봤는데, 열어보니 처음 분류가 세 번 다 조금씩 틀렸다. 아래에 실제로 무엇이었는지 적는다.

## A — 완성돼 있는데 플래그만 안 넘어간 것 (13개)

`95` `274` `481` `483` `482` `462` `484` `223` `410` `292` `377` `374` `375`

"다듬을 게 없다"고 봤지만 3개에 AI가 만들어낸 예제 살이 붙어 있었다. 공개가 목적인데 부풀린 채로 넘기면 앞뒤가 안 맞아서 걷어냈다.

- `375` — `활용: 포커스 관리, 키보드 내비게이션, 접근성 강화, 폼 검증 피드백` 삭제. 예제 4개 중 `keydown` 두 벌이 같은 걸 반복해서 2개로
- `374` — 테스트 4개 → 2개 (복합 예제가 앞의 단순 예제를 이미 덮는다). 첫 줄이 API 이름 나열이라(`및`은 번역투) 실제 요점인 "중첩해서 쓴다"로 교체
- `484` — 첫 줄 뒷부분이 바로 아래 `interface Store` 를 그대로 다시 말하고 있어 삭제

## B — 개인 맥락 (3개)

`archive` 후보로 잡았는데 실제로 개인 맥락이 박힌 건 `276` 하나였다. 셋 다 걷어내니 남는 게 있어 공개로 넘긴다.

- `276` — 사내 서비스명·도메인을 셸 변수로. 코드가 말하지 않는 것(**왜 올린 뒤에 `rm` 하는가**)을 첫 줄에
- `277` — 경로는 일반적이었고, 대신 `scripts` 순서가 거꾸로라 실제 순서(Swagger 2.0 → OpenAPI 3 → zod)가 안 보였다. 2023년 버전이 박힌 `dependencies` 와 스크립트에 안 쓰이는 `orval`·`prettier` 삭제
- `278` — 링크 2개와 코드 2조각이 결론 없이 놓여 있었다. 요점(`ZodError` 가 `ZodiosError.cause` 안에 있어 `instanceof z.ZodError` 로는 안 잡힌다)을 첫 줄로

## C — 진짜 미완성 (6개)

**release 4개**

- `71` — 문장이 `console.trace()를` 에서 끊겨 있었다. 원문에 재료가 다 있어 이어 붙였다
- `294` — 산문이 한 줄도 없어 "왜 Proxy?" 에 답이 없었다. 본문을 한 번만 읽을 수 있다는 전제를 첫 줄로
- `267`·`541` — 이미 최종형. 541은 결론·이유·교훈·참고가 갖춰진 디버그 메모였다

**archive 2개**

- `190` — `premiumSampleRate` 는 현재 Datadog Browser SDK 문서에 없다 (`sessionSampleRate`/`sessionReplaySampleRate` 로 대체). 사라진 필드의 영문 발췌라 공개할 게 없다
- `493` — 무엇을 하려던 것인지 복원할 수 없어 **지어내지 않고** 보관으로 둔다

## mtime

내용을 고친 메모만 갱신했다. 상태만 넘긴 것은 건드리지 않는다 — 재분류는 내용 수정이 아니고, `archive` 도입 때 231개를 옮긴 방식(`a8da78a`)과 같다.

---

`lint:memo` 오류 0 / 경고 0, `lint:voice` 0, `lint:links` 죽은 링크 0 (403 은 전부 MDN·위키피디아·StackOverflow 류 봇 차단 = 확인 불가), `pnpm build` 787페이지 통과.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv2pQrCq9z1GaxxDu2vohK)_