### PR TITLE
feat: 메모 상세에 raw 마크다운 경로 추가

### DIFF
--- a/src/components/Memo/Memo.tsx
+++ b/src/components/Memo/Memo.tsx
@@ -9,10 +9,11 @@ import { MemoDate } from '@components/Memo/MemoDate'
 import { MemoTag } from '@components/Memo/MemoTag'
 import { MemoId } from '@components/Memo/MemoId'
 import { MemoEmbedLink } from '@components/Memo/MemoEmbedLink'
+import { MemoRaw } from '@components/Memo/MemoRaw'
 import type { Props } from './Memo.types'
 import { match, P } from 'ts-pattern'
 
-export function Memo({ type = 'memo', memo, children }: Props) {
+export function Memo({ type = 'memo', raw = false, memo, children }: Props) {
   return (
     <MemoPrimitive>
       {match(memo.data.title)
@@ -30,6 +31,7 @@ export function Memo({ type = 'memo', memo, children }: Props) {
         </MemoTags>
         <MemoIdAndDate>
           <MemoId id={memo.id} type={type} />
+          {raw && <MemoRaw id={memo.id} type={type} />}
           <MemoDate ctime={memo.data.ctime} mtime={memo.data.mtime} />
         </MemoIdAndDate>
       </MemoFooter>

--- a/src/components/Memo/Memo.types.ts
+++ b/src/components/Memo/Memo.types.ts
@@ -6,6 +6,7 @@ export type Category = 'memo' | 'think'
 
 export type Props = {
   type?: Category
+  raw?: boolean
   memo: CollectionEntry<Category>
   children: ComponentProps<typeof MemoBody>['children']
 }

--- a/src/components/Memo/MemoRaw.tsx
+++ b/src/components/Memo/MemoRaw.tsx
@@ -1,0 +1,11 @@
+import { MemoId as MemoIdPrimitive } from '@components/Memo/MemoPrimitive'
+import type { Category } from './Memo.types'
+
+type Props = {
+  type: Category
+  id: string
+}
+
+export function MemoRaw({ type, id }: Props) {
+  return <MemoIdPrimitive href={`/${type}/${id}.md`}>raw</MemoIdPrimitive>
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,6 +18,7 @@ const { pathname } = Astro.url
   <head>
     <BaseHead title={title} description={description} />
     <ClientRouter />
+    <slot name="head" />
   </head>
   <body>
     <Header>

--- a/src/pages/memo/[id].astro
+++ b/src/pages/memo/[id].astro
@@ -41,10 +41,12 @@ const lineage = await getLineage(memo)
 
 const PAGE_TITLE = `메모 - ${memo.data.title || ''} #${memo.id} | eunsoolee`
 const PAGE_DESCRIPTION = memo.data.description || ''
+const RAW_PATH = `/memo/${memo.id}.md`
 ---
 
 <Layout title={PAGE_TITLE} description={PAGE_DESCRIPTION}>
-  <Memo memo={memo}>
+  <link slot="head" rel="alternate" type="text/markdown" href={RAW_PATH} />
+  <Memo memo={memo} raw>
     <Content />
   </Memo>
   <MemoLineage

--- a/src/pages/memo/[id].md.ts
+++ b/src/pages/memo/[id].md.ts
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { APIRoute, GetStaticPaths } from 'astro'
+import { getReleaseMemoCollection } from '@collection/memo'
+
+export const prerender = true
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const memos = await getReleaseMemoCollection()
+
+  return memos.map((memo) => ({
+    params: { id: memo.id },
+    props: { filePath: memo.filePath },
+  }))
+}
+
+// 원본 파일을 그대로 넘긴다 — frontmatter 포함이 raw의 의미
+export const GET: APIRoute = async ({ props }) => {
+  const raw = await readFile(resolve(props.filePath), 'utf-8')
+
+  return new Response(raw, {
+    // text/markdown은 브라우저가 내려받는다. 눌러서 바로 읽히는 게 목적
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+}


### PR DESCRIPTION
`/memo/{id}.md` 로 메모 원본을 그대로 내려준다. LLM/도구가 상세 페이지 HTML 대신 원문을 바로 가져갈 수 있게 하는 게 목적.

## 변경

- `src/pages/memo/[id].md.ts` — release 메모마다 `/memo/{id}.md` 생성. `memo.filePath`의 원본 파일을 읽어서 **frontmatter 포함** 그대로 반환 (`prerender = true`)
- `src/components/Memo/MemoRaw.tsx` + `Memo`의 `raw` prop — 상세 페이지 푸터 `#577` 옆에 `raw` 링크. 목록·태그 페이지에는 노출 안 함
- `src/layouts/Layout.astro` — `<slot name="head" />` 추가
- `src/pages/memo/[id].astro` — `<link rel="alternate" type="text/markdown">` 주입

## 결정

- **소스가 `.mdx`여도 `.md` 하나로 낸다.** URL 모양을 고정해 `/memo/{id}.md`가 항상 존재하게 하는 쪽. 대신 mdx 원본의 `import` 줄과 컴포넌트 블록이 raw에 섞인다 (release 294개 중 45개)
- 응답 헤더는 `text/plain; charset=utf-8`이지만 GitHub Pages 정적 배포에서는 무시되고 Pages가 `.md`에 `text/markdown`을 준다. fetch 용도에는 영향 없음

## 확인

- `pnpm build` 통과, `dist/memo/*.md` 294개 = release 메모 수
- 렌더된 HTML에 `<link rel="alternate">`와 푸터 `raw` 링크 모두 존재
- `vitest run`은 astro 7 + vitest 2 조합으로 startup에서 실패하는데, 이 변경 전 상태에서도 동일하게 실패 (무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv2pQrCq9z1GaxxDu2vohK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv2pQrCq9z1GaxxDu2vohK)_