### PR TITLE
feat: note 52개에 OKF 출처·검증 필드

### DIFF
--- a/src/content/memo/128.md
+++ b/src/content/memo/128.md
@@ -1,9 +1,15 @@
 ---
 type: note
+kind: Reference
 tags: ['extensions']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-29T14:11:20Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-cbcruk-webext
+    resource: https://github.com/cbcruk/webext/commit/cbb36355871fb36d5f6c21752aae3400d2a97abf#diff-0f354ef5fd807996fa3f5a7a83ceb74025aa8f85862e321b8938988031e99711L3-L25
 ---
 
 매니페스트 V3로 마이그레이션[^128-1]

--- a/src/content/memo/134.md
+++ b/src/content/memo/134.md
@@ -1,9 +1,22 @@
 ---
 type: note
+kind: Reference
 tags: ['select', 'css']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2025-03-05T14:44:06Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: adrianroselli-2021-03
+    resource: https://adrianroselli.com/2021/03/under-engineered-select-menus.html
+    title: "Under-Engineered Select Menus | Adrian Roselli"
+  - id: freecodecamp-news-how-to-build-an-accessible
+    resource: https://www.freecodecamp.org/news/how-to-build-an-accessible-custom-dropdown-select-element/#dropdown-keyboard-interaction
+    title: "How to Build an Accessible Custom Dropdown Select Element"
+  - id: clhenrick-accessible-select-element
+    resource: https://clhenrick.io/accessible-select-element/
+    title: "Custom and Accessible Select Menus Aren&#39;t Easy: Part One – Chris Henrick"
 ---
 
 [Under-Engineered Select Menus | Adrian Roselli](https://adrianroselli.com/2021/03/under-engineered-select-menus.html)

--- a/src/content/memo/160.md
+++ b/src/content/memo/160.md
@@ -1,9 +1,21 @@
 ---
 type: note
+kind: Troubleshooting
 tags: ['optimize', 'charles']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-28T21:31:27Z }
+sources:
+  - id: optimize-google
+    resource: https://optimize.google.com/
+    title: "Google Optimize"
+  - id: support-google-optimize-answer
+    resource: https://support.google.com/optimize/answer/6361119?hl=ko&ref_topic=6197696
+    title: "Redirect 테스트"
+  - id: charlesproxy
+    resource: https://www.charlesproxy.com/
+    title: "Charles"
 ---
 
 [Google Optimize](https://optimize.google.com/)에서 [Redirect 테스트](https://support.google.com/optimize/answer/6361119?hl=ko&ref_topic=6197696)를 진행했는데 기능 구현은 문제없는데 세션수가 안 잡히는 문제가 발생했다. 

--- a/src/content/memo/183.md
+++ b/src/content/memo/183.md
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Reference
 tags: ['photoshop']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-28T21:31:27Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-meltingice-psd
+    resource: https://github.com/meltingice/psd.js
+    title: "GitHub - meltingice/psd.js: A Photoshop PSD file parser for NodeJS and browsers"
 ---
 
 [GitHub - meltingice/psd.js: A Photoshop PSD file parser for NodeJS and browsers](https://github.com/meltingice/psd.js)

--- a/src/content/memo/199.md
+++ b/src/content/memo/199.md
@@ -1,9 +1,19 @@
 ---
 type: note
+kind: Reference
 tags: ['storybook', 'chromatic']
 status: release
 ctime: 2022-09-23
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-29T14:11:20Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: chromatic
+    resource: https://www.chromatic.com/
+    title: "chromatic"
+  - id: sabbaticaldev-co-post-chromatic-storybook
+    resource: https://www.sabbaticaldev.co.uk/post/chromatic-storybook
+    title: "Chromatic Storybook - Secure you project token in Next.js"
 ---
 
 [chromatic](https://www.chromatic.com/)

--- a/src/content/memo/218.mdx
+++ b/src/content/memo/218.mdx
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Reference
 tags: ['bdd', 'test']
 status: release
 ctime: 2022-10-16
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2025-03-01T04:55:13Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: school-cucumber-courses-take
+    resource: https://school.cucumber.io/courses/take/bdd-with-cucumber-javascript
+    title: "BDD with Cucumber"
 ---
 
 import QuoteLink from '@components/QuoteLink.astro'

--- a/src/content/memo/22.md
+++ b/src/content/memo/22.md
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Reference
 tags: ['throttle', 'debounce', 'lodash', 'event', 'ui']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-29T14:11:20Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: css-tricks-debouncing-throttling-explained
+    resource: https://css-tricks.com/debouncing-throttling-explained-examples/
+    title: "Debouncing and Throttling Explained Through Examples | CSS-Tricks"
 ---
 
 [Debouncing and Throttling Explained Through Examples | CSS-Tricks](https://css-tricks.com/debouncing-throttling-explained-examples/)[^22-1]

--- a/src/content/memo/27.md
+++ b/src/content/memo/27.md
@@ -1,9 +1,34 @@
 ---
 type: note
+kind: Reference
 tags: ['video', 'ffmpeg', 'canvas']
 status: release
 ctime: 2022-04-09
 mtime: 2025-01-12
+generated: { by: human:cbcruk, at: 2025-03-05T14:44:06Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: rotato-read-transparent-videos-for-the
+    resource: https://www.rotato.app/read/transparent-videos-for-the-web
+    title: "How to use transparent videos on the web in 2021 - Rotato"
+  - id: kitcross-hevc-web-video-alpha-channel
+    resource: https://kitcross.net/hevc-web-video-alpha-channel/
+    title: "How to make HEVC, H265 and VP9 videos with an alpha channel for the web | Kit Cross"
+  - id: curiosalon-github-blog-ffmpeg-alpha-masking
+    resource: https://curiosalon.github.io/blog/ffmpeg-alpha-masking/
+    title: "Alpha Masking with FFMPEG | Curio Museum"
+  - id: developer-mozilla-ko-docs
+    resource: https://developer.mozilla.org/ko/docs/Web/API/Canvas_API/Manipulating_video_using_canvas
+    title: "캔버스(canvas)를 이용한 비디오 조작하기 - Web API | MDN"
+  - id: kapwing-blog-green-screen-in-browser
+    resource: https://www.kapwing.com/blog/green-screen-in-browser/
+    title: "Green Screen in the Browser With HTML Canvas"
+  - id: mux-blog-canvas-adding-filters-and
+    resource: https://mux.com/blog/canvas-adding-filters-and-more-to-video-using-just-a-browser/
+    title: "Canvas: Do cool stuff with video in the browser | Mux blog"
+  - id: stackoverflow-questions-38419980
+    resource: https://stackoverflow.com/questions/38419980/how-to-accurately-filter-rgb-value-for-chroma-key-effect
+    title: "javascript - How to accurately filter RGB value for chroma-key effect - Stack Overflow"
 ---
 
 - [How to use transparent videos on the web in 2021 - Rotato](https://www.rotato.app/read/transparent-videos-for-the-web)

--- a/src/content/memo/270.md
+++ b/src/content/memo/270.md
@@ -1,9 +1,17 @@
 ---
 type: note
+kind: Recipe
 tags: ['react', 'ui', 'confirm', 'react-confirm', 'react-confirm-alert']
 status: release
 ctime: 2023-05-14
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-28T21:31:27Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-haradakunihiko-react-confirm
+    resource: https://github.com/haradakunihiko/react-confirm/tree/master
+  - id: github-ga-mo-react-confirm-alert
+    resource: https://github.com/GA-MO/react-confirm-alert/tree/master
 ---
 
 ```js

--- a/src/content/memo/274.md
+++ b/src/content/memo/274.md
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Reference
 tags: ['terms', '버스-팩터']
 status: release
 ctime: 2023-05-28
 mtime: 2026-07-27
+generated: { by: claude/opus-5, at: 2026-07-27T09:08:53Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: en-wikipedia-wiki-bus-factor
+    resource: https://en.wikipedia.org/wiki/Bus_factor
+    title: "Bus factor - Wikipedia"
 ---
 
 버스 팩터 — 한꺼번에 빠지면 프로젝트가 멈추는 최소 인원 수. 1이면 그 사람이 곧 단일 장애점.

--- a/src/content/memo/28.md
+++ b/src/content/memo/28.md
@@ -1,9 +1,43 @@
 ---
 type: note
+kind: Idea
 tags: ['calendar', 'ui', 'date']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2026-01-05T10:59:14Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-wojtekmaj-react-calendar
+    resource: https://github.com/wojtekmaj/react-calendar/tree/fe83e095f0b744ddaf09bb909bf15d9e45054809
+    title: "react-calendar"
+  - id: github-jquense-react-big-calendar
+    resource: https://github.com/jquense/react-big-calendar
+    title: "react-big-calendar"
+  - id: github-fullcalendar-fullcalendar
+    resource: https://github.com/fullcalendar/fullcalendar
+    title: "fullcalendar"
+  - id: github-schedule-x-schedule-x
+    resource: https://github.com/schedule-x/schedule-x
+    title: "schedule-x"
+  - id: github-gpbl-react-day-picker
+    resource: https://github.com/gpbl/react-day-picker
+    title: "gpbl/react-day-picker"
+  - id: github-deseretdigital-dayzed
+    resource: https://github.com/deseretdigital/dayzed
+    title: "dayzed"
+  - id: github-hacker0x01-react-datepicker
+    resource: https://github.com/Hacker0x01/react-datepicker/
+    title: "react-datepicker"
+  - id: github-its-danny-use-lilius
+    resource: https://github.com/its-danny/use-lilius
+    title: "use-lilius"
+  - id: github-h6s-dev-h6s
+    resource: https://github.com/h6s-dev/h6s/tree/main/packages/calendar
+    title: "h6s"
+  - id: github-you-dont-need-you-dont-need
+    resource: https://github.com/you-dont-need/You-Dont-Need-Momentjs
+    title: "you-dont-need/You-Dont-Need-Momentjs"
 ---
 
 - 컴포넌트[^28-2]

--- a/src/content/memo/301.md
+++ b/src/content/memo/301.md
@@ -1,9 +1,24 @@
 ---
 type: note
+kind: Troubleshooting
 tags: ['astro', 'node', 'memory']
 status: release
 ctime: 2024-04-21
 mtime: 2024-06-06
+generated: { by: human:cbcruk, at: 2024-06-07T22:33:39Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: astro
+    resource: https://astro.build/
+    title: "Astro"
+  - id: nodejs-docs-latest-v20
+    resource: https://nodejs.org/docs/latest-v20.x/api/cli.html#--max-old-space-sizesize-in-megabytes
+    title: "`NODE_OPTIONS=--max_old_space_size`(in megabytes)"
+  - id: docs-astro-en-guides
+    resource: https://docs.astro.build/en/guides/imports/#astroglob
+    title: "`Astro.glob`"
+  - id: stevefenton-co-blog-2023
+    resource: https://www.stevefenton.co.uk/blog/2023/07/astro-javascript-heap-out-of-memory/
 ---
 
 [Astro](https://astro.build/)를 사용한 프로젝트에서 빌드를 하는데 _JavaScript heap out of memory_ 에러가 발생했다.

--- a/src/content/memo/303.md
+++ b/src/content/memo/303.md
@@ -1,5 +1,6 @@
 ---
 type: note
+kind: Reference
 title: Grid View
 description: Grid View의 개념과 주요 특징, 그리고 관련된 오픈 소스 라이브러리들을 소개
 tags:
@@ -14,6 +15,17 @@ tags:
 status: release
 ctime: 2024-06-02
 mtime: 2024-08-12
+generated: { by: human:cbcruk, at: 2024-08-12T21:49:18Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-adazzle-react-data-grid
+    resource: https://github.com/adazzle/react-data-grid
+  - id: github-glideapps-glide-data-grid
+    resource: https://github.com/glideapps/glide-data-grid
+  - id: github-finos-perspective
+    resource: https://github.com/finos/perspective
+  - id: github-teableio-teable
+    resource: https://github.com/teableio/teable
 ---
 
 > [grid view](<(https://en.wikipedia.org/wiki/Grid_view)>)(또는 datagrid)는 데이터의 표 형식 보기를 제공하는 그래픽 제어 요소입니다.

--- a/src/content/memo/305.md
+++ b/src/content/memo/305.md
@@ -1,9 +1,25 @@
 ---
 type: note
+kind: Recipe
 tags: ['google-sheets', 'google-cloud']
 status: release
 ctime: 2024-06-22
 mtime: 2024-06-22
+generated: { by: human:cbcruk, at: 2024-06-22T13:22:05Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: developers-google-sheets-api
+    resource: https://developers.google.com/sheets/api/guides/concepts
+    title: "Google Sheets API"
+  - id: github-theoephraim-node-google
+    resource: https://github.com/theoephraim/node-google-spreadsheet
+    title: "google-spreadsheet"
+  - id: console-cloud-google
+    resource: https://console.cloud.google.com/
+    title: "Google Cloud"
+  - id: thenewstack-how-to-use-google-sheets-as-a
+    resource: https://thenewstack.io/how-to-use-google-sheets-as-a-database-with-react-and-ssr/
+    title: "How To Use Google Sheets as a Database With React via Next.js"
 ---
 
 [Google Sheets API](https://developers.google.com/sheets/api/guides/concepts)를 활용하기 위해서는 Google Cloud Platform(GCP)에서 필요한 설정을 하고, [google-spreadsheet](https://github.com/theoephraim/node-google-spreadsheet) 라이브러리를 통해 스프레드시트를 조작할 수 있습니다. 다음은 이를 위한 단계별 가이드입니다.

--- a/src/content/memo/311.mdx
+++ b/src/content/memo/311.mdx
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Recipe
 tags: ['react']
 status: release
 ctime: 2024-08-13
 mtime: 2024-08-13
+generated: { by: human:cbcruk, at: 2024-08-24T18:51:43Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: buildui-posts-avoiding-premature
+    resource: https://buildui.com/posts/avoiding-premature-abstraction-with-unstyled-react-components
+    title: "buildui.com"
 ---
 
 import {

--- a/src/content/memo/313.md
+++ b/src/content/memo/313.md
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Reference
 tags: ['dialog']
 status: release
 ctime: 2024-09-01
 mtime: 2024-09-01
+generated: { by: human:cbcruk, at: 2026-01-05T10:59:14Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: en-wikipedia-wiki-dialog-box
+    resource: https://en.wikipedia.org/wiki/Dialog_box
+    title: "Dialog box"
 ---
 
 > 대화 상자(Dialog Box)는 사용자에게 정보를 전달하고 응답을 요청하는 그래픽 제어 요소이다.

--- a/src/content/memo/315.mdx
+++ b/src/content/memo/315.mdx
@@ -1,9 +1,20 @@
 ---
 type: note
+kind: Explainer
 tags: ['date', 'test']
 status: release
 ctime: 2024-09-03
 mtime: 2024-09-03
+generated: { by: human:cbcruk, at: 2025-01-12T22:27:54Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-sinonjs-fake-timers
+    resource: https://github.com/sinonjs/fake-timers
+    title: "@sinonjs/fake-timers"
+  - id: jestjs-blog-2020
+    resource: https://jestjs.io/blog/2020/05/05/jest-26#new-fake-timers
+  - id: vitest-guide-mocking
+    resource: https://vitest.dev/guide/mocking#dates
 ---
 
 import { transformerMetaHighlight } from '@shikijs/transformers'

--- a/src/content/memo/333.md
+++ b/src/content/memo/333.md
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Reference
 tags: ['oauth', 'jwt']
 status: release
 ctime: 2025-01-01
 mtime: 2025-01-01
+generated: { by: human:cbcruk, at: 2026-01-05T14:02:23Z }
 ---
 
 Google Auth ID Token 클레임

--- a/src/content/memo/349.md
+++ b/src/content/memo/349.md
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Reference
 tags: ['dialog', 'ux']
 status: release
 ctime: 2025-01-01
 mtime: 2025-01-01
+generated: { by: human:cbcruk, at: 2026-01-05T14:02:23Z }
 ---
 
 대화 상자(Dialog) 유형

--- a/src/content/memo/352.md
+++ b/src/content/memo/352.md
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Recipe
 tags: ['thisisunsafe']
 status: release
 ctime: 2025-01-06
 mtime: 2025-01-06
+generated: { by: human:cbcruk, at: 2025-01-07T07:24:08Z }
 ---
 
 `thisisunsafe`

--- a/src/content/memo/358.mdx
+++ b/src/content/memo/358.mdx
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Reference
 tags: ['field-sizing', 'input', 'textarea', 'select']
 status: release
 ctime: 2025-01-12
 mtime: 2025-01-12
+generated: { by: human:cbcruk, at: 2025-03-01T04:55:13Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: developer-chrome-docs-css-ui
+    resource: https://developer.chrome.com/docs/css-ui/css-field-sizing?&hl=ko
+    title: "CSS 필드 크기 조정"
 ---
 
 import QuoteLink from '@components/QuoteLink.astro'

--- a/src/content/memo/4.md
+++ b/src/content/memo/4.md
@@ -1,9 +1,22 @@
 ---
 type: note
+kind: Idea
 tags: ['blob', 'javascript', 'file', 'axios']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-28T21:31:27Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: medium--fakiolinho-handle-blobs-requests
+    resource: https://medium.com/@fakiolinho/handle-blobs-requests-with-axios-the-right-way-bb905bdb1c04
+    title: "Handle Blobs requests with Axios the right way | by Marios Fakiolas | Medium"
+  - id: heropy-2019-02
+    resource: https://heropy.blog/2019/02/28/blob/
+    title: "Blob(블랍) 이해하기 | HEROPY"
+  - id: pks2974-medium-file-api-ec-a0-95-eb-a6-ac-ed-95
+    resource: https://pks2974.medium.com/file-api-%EC%A0%95%EB%A6%AC%ED%95%98%EA%B8%B0-729fa6a3a0ba
+    title: "File API 정리하기. 최근 FileReader 를 사용할 일이 생겨 File API 를 정리… | by 박성룡 ( Andrew park ) | Medium"
 ---
 
 - 캔버스로 동영상 프레임을 캡쳐한다. 

--- a/src/content/memo/47.md
+++ b/src/content/memo/47.md
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Reference
 tags: ['state', 'ui']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-28T21:31:27Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: dev-davidkpiano-no-disabling-a-button
+    resource: https://dev.to/davidkpiano/no-disabling-a-button-is-not-app-logic-598i
+    title: "No, disabling a button is not app logic. - DEV Community"
 ---
 
 [No, disabling a button is not app logic. - DEV Community](https://dev.to/davidkpiano/no-disabling-a-button-is-not-app-logic-598i)

--- a/src/content/memo/48.md
+++ b/src/content/memo/48.md
@@ -1,9 +1,19 @@
 ---
 type: note
+kind: Reference
 tags: ['react', 'next', 'monorepo', 'hygen', 'husky', 'dependabot']
 status: release
 ctime: 2022-04-09
-mtime: 2024-03-22
+mtime: 2026-08-19
+generated: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: smashingmagazine-2021-11
+    resource: https://www.smashingmagazine.com/2021/11/maintain-large-nextjs-application/
+    title: "How To Maintain A Large Next.js Application — Smashing Magazine"
+  - id: nextjs-docs-going-to-production
+    resource: https://nextjs.org/docs/app/guides/production-checklist
+    title: "Production Checklist | Next.js"
 ---
 
 [How To Maintain A Large Next.js Application — Smashing Magazine](https://www.smashingmagazine.com/2021/11/maintain-large-nextjs-application/)
@@ -17,4 +27,4 @@ mtime: 2024-03-22
 - UI 구성 요소 시각화를 위해 스토리북 사용
 - 처음부터 유지 관리 가능한 테스트 작성
 - Dependabot을 사용하여 자동으로 패키지 업데이트
-- [Going to Production | Next.js](https://nextjs.org/docs/going-to-production)
+- [Production Checklist | Next.js](https://nextjs.org/docs/app/guides/production-checklist)

--- a/src/content/memo/500.md
+++ b/src/content/memo/500.md
@@ -1,9 +1,22 @@
 ---
 type: note
+kind: Idea
 tags: [sqlite, bun, neovim, vscode, cli]
 status: release
 ctime: 2025-12-26
 mtime: 2025-12-26
+generated: { by: human:cbcruk, at: 2026-01-05T10:59:14Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-nvim-telescope-telescope
+    resource: https://github.com/nvim-telescope/telescope.nvim
+    title: "Neovim Telescope"
+  - id: code-visualstudio-api
+    resource: https://code.visualstudio.com/api
+    title: "VS Code 확장"
+  - id: bun-docs-bundler
+    resource: https://bun.sh/docs/bundler/executables
+    title: "Bun Single-file Executable"
 ---
 
 MDIR 스타일 인터페이스 개발 - SQLite DB를 탐색하는 도구

--- a/src/content/memo/53.md
+++ b/src/content/memo/53.md
@@ -1,9 +1,22 @@
 ---
 type: note
+kind: Explainer
 tags: ['fetch', 'preflight', 'simple-requests']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-29T14:11:20Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: developer-mozilla-en-us-docs
+    resource: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests
+    title: "조건"
+  - id: developer-mozilla-ko-docs
+    resource: https://developer.mozilla.org/ko/docs/Web/HTTP/CORS#%EB%8B%A8%EC%88%9C_%EC%9A%94%EC%B2%ADsimple_requests
+    title: "단순 요청(Simple requests)"
+  - id: aws-amazon-ko-premiumsupport
+    resource: https://aws.amazon.com/ko/premiumsupport/knowledge-center/no-access-control-allow-origin-error/
+    title: "CloudFront 배포의 캐시 동작이 HTTP 요청에 대한 OPTIONS 메서드를 허용함"
 ---
 
 - [조건](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests)에 따라서 브라우저에서 자동으로 발생[^53-1]

--- a/src/content/memo/539.md
+++ b/src/content/memo/539.md
@@ -1,9 +1,25 @@
 ---
 type: note
+kind: Troubleshooting
 tags: ['url', 'encoding', 'ios', 'debug', 'security']
 status: release
 ctime: 2026-05-25
 mtime: 2026-05-31
+generated: { by: human:cbcruk, at: 2026-05-31T16:41:08Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: bugs-webkit-show-bug
+    resource: https://bugs.webkit.org/show_bug.cgi?id=261936
+    title: "WebKit Bug 261936"
+  - id: augmentedcode-2023-10
+    resource: https://augmentedcode.io/2023/10/02/changes-to-url-string-parsing-in-ios-17/
+    title: "Changes to URL string parsing in iOS 17 — Augmented Code"
+  - id: owasp-www-community-double-encoding
+    resource: https://owasp.org/www-community/Double_Encoding
+    title: "OWASP — Double Encoding"
+  - id: url-spec-whatwg
+    resource: https://url.spec.whatwg.org/
+    title: "WHATWG URL Standard"
 ---
 
 URL `%2520` 버그 = iOS 17.0/17.1 WebKit pasteboard가 복사 시 URL을 재인코딩 (WebKit Bug 261936).

--- a/src/content/memo/541.md
+++ b/src/content/memo/541.md
@@ -1,10 +1,23 @@
 ---
 type: note
+kind: Explainer
 tags:
   ['inspect-webkit', 'ios', 'debug', 'safari', 'webview', 'mobile', 'tooling']
 status: release
 ctime: 2026-05-25
 mtime: 2026-06-02
+generated: { by: human:cbcruk, at: 2026-06-07T22:55:16Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-evanbacon-inspect-webkit
+    resource: https://github.com/EvanBacon/inspect-webkit
+    title: "inspect-webkit"
+  - id: github-liriliri-eruda
+    resource: https://github.com/liriliri/eruda
+    title: "Eruda"
+  - id: developer-apple-documentation-safari-developer
+    resource: https://developer.apple.com/documentation/safari-developer-tools/inspecting-ios
+    title: "Inspecting iOS and iPadOS — Apple"
 ---
 
 시뮬레이터 Safari를 GUI로 디버깅하는 정도는 그냥 **macOS Safari 개발자용 메뉴**. inspect-webkit(CDP 브리지)으로 우회하려다 막혔다.

--- a/src/content/memo/547.md
+++ b/src/content/memo/547.md
@@ -1,5 +1,6 @@
 ---
 type: note
+kind: Explainer
 tags:
   [
     'preact',
@@ -11,6 +12,12 @@ tags:
 status: release
 ctime: 2026-06-03
 mtime: 2026-06-03
+generated: { by: human:cbcruk, at: 2026-06-07T22:39:32Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-developit-mixed-signals
+    resource: https://github.com/developit/mixed-signals
+    title: "developit/mixed-signals"
 ---
 
 풀스택 경계의 통합 단위 = reactive state 그 자체. 서버의 signal/model이 클라이언트에서 *같은 객체*로 보인다.

--- a/src/content/memo/548.md
+++ b/src/content/memo/548.md
@@ -1,5 +1,6 @@
 ---
 type: note
+kind: Explainer
 tags:
   [
     'agile',
@@ -13,6 +14,7 @@ tags:
 status: release
 ctime: 2026-06-07
 mtime: 2026-06-07
+generated: { by: human:cbcruk, at: 2026-06-07T22:55:16Z }
 ---
 
 애자일 의식(스쿼드·2주 스프린트·스탠드업)을 다 갖춰도, 수직 슬라이싱이 없으면 2주 컨테이너에 워터폴을 압축한 cargo cult agile이 된다.

--- a/src/content/memo/550.md
+++ b/src/content/memo/550.md
@@ -1,10 +1,17 @@
 ---
 type: note
+kind: Explainer
 tags:
   ['canvas', 'compression', 'png', 'deflate', 'browser', 'hack', 'javascript']
 status: release
 ctime: 2026-06-07
 mtime: 2026-06-07
+generated: { by: human:cbcruk, at: 2026-06-07T22:55:16Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: jstrieb-github-posts-canvas-compress
+    resource: https://jstrieb.github.io/posts/canvas-compress/
+    title: "Using the Browser's `<canvas>` for Data Compression — Jacob Strieb"
 ---
 
 PNG을 범용 압축 컨테이너로 해킹 — 임의의 바이트를 canvas 픽셀(R/G/B)에 인코딩하고 `toDataURL("image/png")`을 부르면 브라우저 내장 Deflate 압축을 JS에서 끌어쓸 수 있다. 복원은 `<img>`로 다시 로드해 `getImageData`로 픽셀을 읽는다.

--- a/src/content/memo/553.mdx
+++ b/src/content/memo/553.mdx
@@ -1,10 +1,17 @@
 ---
 type: note
+kind: Explainer
 tags: ['browser-extension', 'native-messaging', 'chrome']
 status: release
 ctime: 2026-06-08
 mtime: 2026-06-28
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
 title: Native Messaging — 확장이 로컬 바이너리를 실행하는 법
+sources:
+  - id: developer-chrome-docs-extensions
+    resource: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+    title: "Native messaging — Chrome for Developers"
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/555.mdx
+++ b/src/content/memo/555.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['navigation-api', 'router', 'lean']
 status: release
 ctime: 2026-06-15
 mtime: 2026-06-28
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/558.mdx
+++ b/src/content/memo/558.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['knip', 'reachability', 'dead-code', 'graph']
 status: release
 ctime: 2026-06-16
 mtime: 2026-06-28
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/559.mdx
+++ b/src/content/memo/559.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['javascript', 'event-loop', 'microtask']
 status: release
 ctime: 2026-06-18
 mtime: 2026-06-27
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/560.mdx
+++ b/src/content/memo/560.mdx
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Explainer
 tags: ['react', 'fiber', 'algorithm', 'dfs']
 status: release
 ctime: 2026-06-21
-mtime: 2026-06-27
+mtime: 2026-08-19
+generated: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-facebook-react
+    resource: https://github.com/react/react/issues/7942
+    title: "React Fiber Architecture — facebook/react#7942"
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
@@ -30,4 +37,4 @@ import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
 
 ---
 
-- 참고: [React Fiber Architecture — facebook/react#7942](https://github.com/facebook/react/issues/7942)
+- 참고: [React Fiber Architecture — facebook/react#7942](https://github.com/react/react/issues/7942)

--- a/src/content/memo/561.mdx
+++ b/src/content/memo/561.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Convention
 tags: ['local-first', 'indexeddb', 'sync']
 status: release
 ctime: 2026-06-21
 mtime: 2026-06-27
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/562.mdx
+++ b/src/content/memo/562.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Convention
 tags: ['signals', 'reactivity', 'build-tooling', 'architecture']
 status: release
 ctime: 2026-06-21
 mtime: 2026-06-21
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 <img

--- a/src/content/memo/565.mdx
+++ b/src/content/memo/565.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['chrome-devtools', 'cdp', 'websocket', 'proxy']
 status: release
 ctime: 2026-06-23
 mtime: 2026-06-23
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 핵심 한 줄: 원격 호스팅 DevTools 프론트엔드(`appspot.com`)를 로컬 CDP에 붙이되, 중간에 **로컬 프록시(9223)를 끼워 Chrome의 cross-origin WebSocket 거부를 우회**한다.

--- a/src/content/memo/567.mdx
+++ b/src/content/memo/567.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['performance', 'rendering', 'fouc', 'html']
 status: release
 ctime: 2026-06-23
 mtime: 2026-06-23
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/568.mdx
+++ b/src/content/memo/568.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['probability', 'coupon-collector', 'math']
 status: release
 ctime: 2026-06-23
 mtime: 2026-06-27
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/569.mdx
+++ b/src/content/memo/569.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['javascript', 'event-loop', 'navigation']
 status: release
 ctime: 2026-06-23
 mtime: 2026-06-23
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 <img

--- a/src/content/memo/570.mdx
+++ b/src/content/memo/570.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['react', 'usememo', 'usedeferredvalue', 'formal-verification', 'lean']
 status: release
 ctime: 2026-06-23
 mtime: 2026-06-27
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/572.mdx
+++ b/src/content/memo/572.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['lean', 'formal-verification', 'http', 'abort', 'cancellation']
 status: release
 ctime: 2026-06-23
 mtime: 2026-06-27
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/573.mdx
+++ b/src/content/memo/573.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['react', 'css', 'loading-ux', 'formal-verification', 'lean']
 status: release
 ctime: 2026-06-23
 mtime: 2026-06-27
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'

--- a/src/content/memo/575.mdx
+++ b/src/content/memo/575.mdx
@@ -1,9 +1,11 @@
 ---
 type: note
+kind: Explainer
 tags: ['react', 'suspense', 'declarative', 'formal-verification', 'lean']
 status: release
 ctime: 2026-06-23
 mtime: 2026-06-27
+generated: { by: human:cbcruk, at: 2026-06-28T14:49:32Z }
 ---
 
 declarative Combobox = `render ∘ query ∘ defer`. Suspense가 `query: Q→Promise⟨D⟩`를 throw로 바꿔 동기 `Q→D`로 위장하니, 전체가 명령형 조율이 아니라 함수 합성이 된다.

--- a/src/content/memo/63.md
+++ b/src/content/memo/63.md
@@ -1,9 +1,15 @@
 ---
 type: note
+kind: Reference
 tags: ['node', 'image', 'imagemin']
 status: release
 ctime: 2022-04-09
 mtime: 2026-07-27
+generated: { by: claude/opus-5, at: 2026-07-28T06:13:42Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-antonreshetov-image-optimizer
+    resource: https://github.com/antonreshetov/image-optimizer/blob/master/src/main/store/module/app.ts#L33-L53
 ---
 
 - 이미지 압축 기본 설정값 참조: mozjpeg(75), pngquant([75, 85])[^63-1]

--- a/src/content/memo/7.md
+++ b/src/content/memo/7.md
@@ -1,10 +1,17 @@
 ---
 type: note
+kind: Reference
 tags: ['plugin', 'javascript']
 status: release
 embed: https://stackblitz.com/edit/js-xjtc7p?file=index.js
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-29T14:11:20Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: css-tricks-designing-a-javascript-plugin
+    resource: https://css-tricks.com/designing-a-javascript-plugin-system/
+    title: "Designing a JavaScript Plugin System | CSS-Tricks"
 ---
 
 [Designing a JavaScript Plugin System | CSS-Tricks](https://css-tricks.com/designing-a-javascript-plugin-system/)[^7-1]

--- a/src/content/memo/71.md
+++ b/src/content/memo/71.md
@@ -1,9 +1,19 @@
 ---
 type: note
+kind: Recipe
 tags: ['redux', 'debug']
 status: release
 ctime: 2022-04-09
 mtime: 2026-08-02
+generated: { by: claude/opus-5, at: 2026-08-02T13:56:30Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: github-zalmoxisus-redux-devtools
+    resource: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Features/Trace.md
+    title: "trace 설정"
+  - id: developer-mozilla-ko-docs
+    resource: https://developer.mozilla.org/ko/docs/Web/API/Console/trace
+    title: "`console.trace()`"
 ---
 
 redux 에서 trace 가 필요하면 redux-devtools 의 [trace 설정](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Features/Trace.md)을 켠다. 다만 메모리 릭 가능성이 있어서 상시로 켜두긴 어렵다 — 우회한다면 무식하지만 의심 지점에 [`console.trace()`](https://developer.mozilla.org/ko/docs/Web/API/Console/trace)를 직접 넣는다.

--- a/src/content/memo/78.md
+++ b/src/content/memo/78.md
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Reference
 tags: ['cse', 'api']
 status: release
 ctime: 2022-04-09
 mtime: 2026-07-27
+generated: { by: claude/opus-5, at: 2026-07-28T06:25:42Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: developers-google-custom-search-v1
+    resource: https://developers.google.com/custom-search/v1/reference/rest/v1/cse.siterestrict/list
+    title: "Method: cse.siterestrict.list"
 ---
 
 > 검색기능을 정말 간단하게 구현하고 싶을때:

--- a/src/content/memo/95.md
+++ b/src/content/memo/95.md
@@ -1,9 +1,15 @@
 ---
 type: note
+kind: Recipe
 tags: ['tools', 'filezilla', 'ftp']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-28T21:31:27Z }
+sources:
+  - id: filezilla-project-download
+    resource: https://filezilla-project.org/download.php?type=server
+    title: "파일질라 서버"
 ---
 
 1. [파일질라 서버](https://filezilla-project.org/download.php?type=server)를 설치

--- a/src/content/memo/97.md
+++ b/src/content/memo/97.md
@@ -1,9 +1,16 @@
 ---
 type: note
+kind: Recipe
 tags: ['google-apps-script', 'slack']
 status: release
 ctime: 2022-04-09
 mtime: 2024-03-22
+generated: { by: human:cbcruk, at: 2024-03-29T14:11:20Z }
+verified: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
+sources:
+  - id: davidwalsh-using-slack-slash-commands-to
+    resource: https://davidwalsh.name/using-slack-slash-commands-to-send-data-from-slack-into-google-sheets
+    title: "Using Slack Slash Commands to Send Data from Slack into Google Sheets"
 ---
 
 [Using Slack Slash Commands to Send Data from Slack into Google Sheets](https://davidwalsh.name/using-slack-slash-commands-to-send-data-from-slack-into-google-sheets)


### PR DESCRIPTION
공개 `note` 60개 중 미처리 52개. #26 과 달리 선정 기준이 "에이전트가 다시 쓴 것"이 아니라 **type 전체**다.

```
generated 52/52   sources 35/52   kind 52/52   verified 33/52
```

## 이전 배치와 정반대

**48/52 가 저자 본문이다** (#26 은 19/19 가 에이전트). `note` 는 대부분 직접 쓴 글이라는 뜻이다.

`sources` 없는 17개는 **출처 누락이 아니라 원저작**이다 — `569`(location.href setter 타이밍)·`572`(HTTP 요청 취소)·`575`(declarative Combobox) 처럼 읽고 정리한 게 아니라 직접 분석한 글. OKF 는 "이건 내가 처음 쓴 것"을 표현할 방법이 없고 생략만 가능하다.

## kind 분포

| kind | 개수 |
|---|---|
| `Explainer` 메커니즘 설명 | 19 |
| `Reference` 자료·정의·요약 | 18 |
| `Recipe` 절차·설정 | 7 |
| `Troubleshooting` 현상→원인→해결 | 3 |
| `Idea` 만들 것·조사 | 3 |
| `Convention` 규율 | 2 |

`Troubleshooting`·`Idea` 는 새 어휘다. OKF `type` 은 중앙 등록이 없으니 문제는 없다.

## 검증 — 방식 3(섞기)

- **깊은 검증 7건** — `Explainer` 중 `sources` 가 있는 것. 출처를 실제로 가져와 주장과 대조했다. 전부 확인됨:

  | 메모 | 대조 결과 |
  |---|---|
  | `53` | MDN 이 simple request 조건과 OPTIONS preflight 를 그대로 문서화 |
  | `315` | Jest 26 블로그 — *"new implementation of fake timers based on `@sinonjs/fake-timers`"* |
  | `541` | inspect-webkit README — *"written for AI agents and CI"* |
  | `547` | mixed-signals README — *"access reactive model state and methods from a server as if they lived on the client"* |
  | `550` | jstrieb — *"compress arbitrary data by leveraging browsers' ability to losslessly compress pixel data into a PNG"* |
  | `553` | Chrome 문서 — *"preceded with 32-bit message length in native byte order"* |
  | `560` | React 이슈 본문에 `child`/`sibling`/`return` 순회 코드 |

- **생존 확인 26건**
- **제외**: `95`(네트워크 도달 실패 — 죽음이 아니라 판정 보류), `160`(아래), `sources` 없는 17개(대조 대상 자체가 없음)

## 검증에서 걸린 것

| 메모 | 문제 | 처리 |
|---|---|---|
| `48` | `nextjs.org/docs/going-to-production` 404 | `app/guides/production-checklist` 로 교체 |
| `560` | **`facebook/react` → `react/react` 조직 이름 변경**으로 404 | 새 URL 로 교체. 이슈 본문에 순회 코드가 그대로 있어 주장은 확인됨 |
| `160` | **Google Optimize 종료** — 죽은 링크 2건 | 서비스 자체가 사라져 기계적으로 못 고친다. **판단 필요** |

## 전사 버그 수정

- 각주가 **맨 URL**(마크다운 링크가 아닌)인 경우 `[^63-1]: ` 접두사 때문에 추출이 안 됐다 — `63`·`128`
- JSX 링크 컴포넌트를 추출에 추가. `lint-memo` 의 `LINK_COMPONENT` 와 같은 규칙(`url`/`href` 만, `<img>`·`<AutoIframe>` 의 `src` 는 로컬 자산이라 제외)

## 검증

- `pnpm lint:memo` — 539개, 오류 0 · 경고 0
- `astro build` — 784페이지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
