### PR TITLE
memo: 160 에 서비스 종료 표시 — Google Optimize

### DIFF
--- a/src/content/memo/160.md
+++ b/src/content/memo/160.md
@@ -4,8 +4,8 @@ kind: Troubleshooting
 tags: ['optimize', 'charles']
 status: release
 ctime: 2022-04-09
-mtime: 2024-03-22
-generated: { by: human:cbcruk, at: 2024-03-28T21:31:27Z }
+mtime: 2026-08-19
+generated: { by: claude/opus-5, at: 2026-08-19T00:00:00Z }
 sources:
   - id: optimize-google
     resource: https://optimize.google.com/
@@ -13,13 +13,22 @@ sources:
   - id: support-google-optimize-answer
     resource: https://support.google.com/optimize/answer/6361119?hl=ko&ref_topic=6197696
     title: "Redirect 테스트"
+  - id: support-google-optimize-sunset
+    resource: https://support.google.com/optimize/answer/12979939
+    title: "Google Optimize sunset"
   - id: charlesproxy
     resource: https://www.charlesproxy.com/
     title: "Charles"
 ---
+
+> [!WARNING]
+> **Google Optimize는 2023년 9월 30일 종료됐다**[^optimize-sunset] — 아래 Optimize 링크 둘은 살아 있지 않다.
+> 남는 건 서비스가 아니라 교훈이다: **리다이렉트에서 query를 갈아끼우면 그 query에 실려 있던 측정 정보가 사라진다.**
 
 [Google Optimize](https://optimize.google.com/)에서 [Redirect 테스트](https://support.google.com/optimize/answer/6361119?hl=ko&ref_topic=6197696)를 진행했는데 기능 구현은 문제없는데 세션수가 안 잡히는 문제가 발생했다. 
 
 이번에 문제되었던 부분은 query 처리를 인지하지 못했던 점이었다. Optimize에서 redirect 처리가 이루어질 때 `query`에 정보(예. `utm_expid`)들이 추가되는데 리다이렉트 url 변경하는 부분이 있었고 optimize에서 참조되어야 할 query를 날려버리면서 측정이 불가능했던 것. 결국 `replace` 실행 코드를 이전 query를 assign 시켜주도록 변경해서 해결.
 
 여담이지만 [Charles](https://www.charlesproxy.com/)를 사용하고 있어서 배포 없이 테스트 가능했던 점도 같이 메모.
+
+[^optimize-sunset]: [Google Optimize sunset](https://support.google.com/optimize/answer/12979939)


### PR DESCRIPTION
#28 검증에서 나온 마지막 미해결 건. 죽은 링크 2건이 **고칠 수 있는 종류가 아니었다** — 서비스 자체가 없어졌다.

> "Google Optimize and Optimize 360 are no longer available as of September 30, 2023."

## 변경

- 본문 머리에 종료 표시. 공식 종료 공지를 각주(`[^optimize-sunset]`)로 달고 `sources` 에도 추가
- **남는 게 무엇인지 한 줄로 적었다** — 서비스가 아니라 교훈이다: *리다이렉트에서 query 를 갈아끼우면 그 query 에 실려 있던 측정 정보가 사라진다*
- 죽은 링크 둘은 **그대로 둔다.** 당시 무엇을 참조했는지가 기록이고, 머리말이 살아 있지 않다는 걸 알려준다
- 본문을 고쳤으므로 `mtime`·`generated` 갱신

## `verified` 는 달지 않는다

출처 둘이 영구히 사라져서 대조할 대상이 없다. OKF §5.2 의 *"confirmed against its sources or resource"* 가 성립하지 않으므로 unverified 로 두는 게 정확하다. 머리말이 그 이유를 사람에게 알려준다.

## 검증

- `pnpm lint:memo` — 539개, 오류 0 · 경고 0
- `astro build` — 784페이지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
