### PR TITLE
style: 메모 본문 표 스타일

### DIFF
--- a/src/components/Memo/MemoBody.module.css
+++ b/src/components/Memo/MemoBody.module.css
@@ -89,6 +89,37 @@
   @apply p-2 bg-(--flexoki-950) text-[10px] rounded-md;
 }
 
+/* 표 — 메모 카드가 overflow-hidden 이라 표가 스스로 스크롤해야 잘리지 않는다 */
+.root table {
+  @apply block max-w-full overflow-x-auto text-[12px];
+  border-collapse: collapse;
+}
+
+.root th,
+.root td {
+  @apply px-2 py-1.5 text-left align-top;
+  border-bottom: 1px solid var(--flexoki-950);
+}
+
+.root th {
+  @apply font-bold whitespace-nowrap text-(--flexoki-100);
+  border-bottom-color: var(--flexoki-800);
+}
+
+.root td {
+  @apply text-(--flexoki-300);
+}
+
+.root tr:last-child td {
+  @apply border-b-0;
+}
+
+/* 표 안의 인라인 코드는 셀 높이를 키우지 않게 줄인다 */
+.root td code:not(pre > code),
+.root th code:not(pre > code) {
+  @apply px-1 py-0 rounded text-[11px];
+}
+
 .root [data-footnote-ref]::before {
   content: '[';
 }


### PR DESCRIPTION
표가 스타일 없이 브라우저 기본으로 렌더되고 있었다. OKF 도입 이후 `# Schema` 같은 표가 늘어 눈에 띈다.

대상: 공개 메모 6개 — `28` `333` `524` `537` `538` `576`

## 제약 하나

메모 카드가 `overflow-hidden` 이다 (`MemoPrimitive.tsx:3`). 넓은 표는 스크롤되는 게 아니라 **잘린다.** 그래서 표 자체를 스크롤 컨테이너로 만들었다.

## 설계

| 결정 | 이유 |
|---|---|
| `display:block` + `overflow-x:auto` | 카드를 넘치는 표만 스크롤. 좁은 표는 내용 폭에 맞춰 왼쪽 정렬되고, 셀 텍스트는 그대로 줄바꿈된다 (`width:max-content` 를 쓰지 않은 이유 — 긴 셀이 항상 스크롤을 만든다) |
| `12px` | 본문 14px, 코드 12px, 인용 10px 사이에서 코드 단. 표는 밀도가 높다 |
| 가로 구분선만 | 세로선 없음. `hr`·카드와 같은 `--flexoki-950`, 헤더 밑줄만 `--flexoki-800` 으로 한 단계 올림 |
| `th` = `--flexoki-100` + `nowrap` | `strong` 과 같은 색. 코퍼스의 헤더는 전부 짧다 |
| 셀 안 인라인 코드 축소 | 기본 `p-1 text-xs` 는 표 행 높이를 키운다 → `px-1 py-0 text-[11px]` |

## 확인 필요

**시각 확인을 못 했다** — 이 세션에 브라우저 도구가 없다. 빌드와 생성된 CSS 규칙까지만 확인했다:

- `pnpm lint:memo` 539개 오류 0 · 경고 0, `astro build` 784페이지
- 번들에 규칙 6개 전부 포함 확인 (`MemoBody.*.css`)

개발 서버를 띄워뒀으니 직접 봐주면 좋겠다:

```
http://localhost:4321/memo/576   # 3열, 셀에 인라인 코드 — 가장 빡센 경우
http://localhost:4321/memo/333   # 2열, 짧은 헤더
http://localhost:4321/memo/524   # 3열, 셀 텍스트가 긴 경우
```

특히 볼 것: `576` 의 `(typeof DATE_FORMATS)[number]` 셀이 카드를 넘겨 스크롤되는지, 아니면 줄바꿈으로 들어가는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
