### PR TITLE
memo: 575 대수적 효과에 각주

### DIFF
--- a/src/content/memo/575.md
+++ b/src/content/memo/575.md
@@ -4,8 +4,12 @@ kind: Explainer
 tags: ['react', 'suspense', 'declarative']
 status: release
 ctime: 2026-06-23
-mtime: 2026-08-19
-generated: { by: claude/opus-5, at: 2026-08-19T13:00:00Z }
+mtime: 2026-08-20
+generated: { by: claude/opus-5, at: 2026-08-20T00:00:00Z }
+sources:
+  - id: algebraic-effects
+    resource: https://overreacted.io/algebraic-effects-for-the-rest-of-us/
+    title: "Algebraic Effects for the Rest of Us"
 ---
 
 Suspense는 **비동기를 동기처럼 보이게** 만든다. 데이터가 아직 없으면 promise를 던지고, React가 그걸 받아 기다렸다가 다시 그린다. 그래서 상태를 조율하는 대신 **입력을 미루고 → 질의하고 → 그리는** 순서로 끝난다.
@@ -20,6 +24,8 @@ Suspense는 **비동기를 동기처럼 보이게** 만든다. 데이터가 아�
 
 ---
 
-곁가지 — 인자를 위로 들어올려 바깥이 처리하게 하는 이 모양은 대수적 효과(algebraic effects)의 handler와 같다.
+곁가지 — 인자를 위로 들어올려 바깥이 처리하게 하는 이 모양은 대수적 효과(algebraic effects)의 handler와 같다.[^algebraic-effects]
+
+[^algebraic-effects]: `try/catch`와 비슷하다 — 중간 함수들은 몰라도 되고 가장 가까운 handler가 받는다. 다른 점은 **처리하고 끝나지 않는다**는 것이다. handler가 값을 돌려주면 효과를 일으킨 자리로 되돌아가 실행이 이어진다. ([Algebraic Effects for the Rest of Us](https://overreacted.io/algebraic-effects-for-the-rest-of-us/))
 
 stale-while-revalidate(두 시계·isStale) 부분은 [570](/memo/570)으로.


### PR DESCRIPTION
곁가지 한 줄이 *"대수적 효과(algebraic effects)의 handler와 같다"*고만 하고 지나갔다. 널리 쓰이는 용어가 아니라 6개월 뒤엔 그 줄이 다시 해독 대상이 된다.

## 각주

> `try/catch`와 비슷하다 — 중간 함수들은 몰라도 되고 가장 가까운 handler가 받는다. 다른 점은 **처리하고 끝나지 않는다**는 것이다. handler가 값을 돌려주면 효과를 일으킨 자리로 되돌아가 실행이 이어진다.

지어내지 않고 출처에서 확인한 문장만 옮겼다:

| 각주 | 출처 |
|---|---|
| `try/catch`와 비슷 | *"If you're familiar with `try / catch` blocks, you'll figure out algebraic effects very fast."* |
| 중간 함수는 몰라도 된다 | *"Things in the middle don't need to concern themselves with error handling."* |
| 처리하고 끝나지 않는다 | *"once we hit an error, we can't continue... But with algebraic effects, **we can**."* |
| 값을 돌려주면 그 자리로 되돌아간다 | *"jump back to where we performed the effect, and pass something back to it from the handler"* |

## sources

```yaml
sources:
  - id: algebraic-effects
    resource: https://overreacted.io/algebraic-effects-for-the-rest-of-us/
    title: "Algebraic Effects for the Rest of Us"
```

각주 라벨을 `sources[].id`와 맞췄다 — `docs/memo-spec.md` "OKF concept" 절의 규약.

`sources`는 zod가 strip해서 **화면에는 안 보이므로** 각주 안에도 링크를 뒀다. 사람은 각주로, 에이전트는 frontmatter(`/memo/575.md`·`/llms-full.txt`)로 같은 출처에 닿는다.

`575`는 #28에서 *"원저작이라 출처 없음"*으로 분류했던 17개 중 하나였는데, 이제 `sources`를 갖는다.

## 검증

- `pnpm lint:memo` — 539개, 오류 0 · 경고 0 (각주 참조↔정의 짝 포함)
- `astro build` — 782페이지
- 렌더 확인: 정의가 본문에서 사라지고 하단 `data-footnotes` 섹션으로 수집, backref 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
