### PR TITLE
memo: 570 을 useDeferredValue / useMemo 로 분리 + 초등학생 눈높이

### DIFF
--- a/public/iframe/useMemo_cache_behavior.html
+++ b/public/iframe/useMemo_cache_behavior.html
@@ -93,25 +93,21 @@
 </head>
 <body>
 <div class="wrap">
+<h2 class="sr-only">useMemo 재활용 동작 비교. items 참조가 매번 새로 생기는 경우, 안정한 경우, 그리고 재료 목록에 없는 값을 계산이 몰래 쓰는 경우 — 앞의 둘은 느려질 뿐이고 마지막만 답이 틀린다.</h2>
 <div style="padding: 1rem 0">
   <div class="tab-bar">
-    <div class="tab active" onclick="setTab(0)">items 불안정 (인라인 생성)</div>
-    <div class="tab" onclick="setTab(1)">items 안정 (useMemo 처리)</div>
+    <div class="tab active" onclick="setTab(0)">items를 매번 새로 만들면</div>
+    <div class="tab" onclick="setTab(1)">items 참조가 그대로면</div>
+    <div class="tab" onclick="setTab(2)">재료에 안 적어둔 값을 쓰면</div>
   </div>
 
-  <div id="desc-0" class="scenario-desc">
-    부모가 <code style="font-size:11px">items={'{'}data.map(transform){'}'}</code> 처럼 매 렌더마다 새 배열 참조를 내려보내는 경우
-  </div>
-  <div id="desc-1" class="scenario-desc" style="display:none">
-    부모가 <code style="font-size:11px">const items = useMemo(() =&gt; ..., [rawData])</code> 으로 안정화된 참조를 내려보내는 경우
-  </div>
+  <div id="desc" class="scenario-desc"></div>
 
   <div class="legend">
-    <div class="leg"><div class="leg-dot" style="background:#fbbf24"></div>값 변경</div>
-    <div class="leg"><div class="leg-dot" style="background:#34d399"></div>캐시 재사용</div>
-    <div class="leg"><div class="leg-dot" style="background:#ef4444"></div>재계산 실행</div>
-    <div class="leg"><div class="leg-dot" style="background:#a78bfa; opacity:.6"></div>지연된 값 (stale)</div>
-    <div class="leg"><div class="leg-dot" style="background:var(--color-background-secondary)"></div>변화 없음</div>
+    <div class="leg"><div class="leg-dot" style="background:#fbbf24"></div>바뀜</div>
+    <div class="leg"><div class="leg-dot" style="background:#34d399"></div>재활용 / 맞음</div>
+    <div class="leg"><div class="leg-dot" style="background:#ef4444"></div>다시 계산 / 틀림</div>
+    <div class="leg"><div class="leg-dot" style="background:var(--color-background-secondary)"></div>그대로</div>
   </div>
 
   <div class="tick-labels" id="tick-labels"></div>
@@ -122,83 +118,56 @@
 </div>
 
 <script>
+const TICKS = ['타이핑', '부모 리렌더', 'rawData 변경', '타이핑'];
+
 const SCENARIOS = [
   {
-    triggers: [
-      { label: 'query 타이핑', queryChange: true, itemsChange: true, deferredChange: false },
-      { label: 'deferred 반영', queryChange: false, itemsChange: true, deferredChange: true },
-      { label: '부모 리렌더', queryChange: false, itemsChange: true, deferredChange: false },
-      { label: 'rawData 변경', queryChange: false, itemsChange: true, deferredChange: true },
+    desc: '부모가 <code>items={data.map(transform)}</code> 처럼 매 렌더마다 새 배열을 내려보내는 경우',
+    rows: [
+      { label: 'items 참조', cells: ['새로움', '새로움', '새로움', '새로움'] },
+      { label: 'useMemo', cells: ['다시 계산', '다시 계산', '다시 계산', '다시 계산'] },
+      { label: '화면의 답', cells: ['맞음', '맞음', '맞음', '맞음'] },
     ],
     result: [
-      { key: 'isStale 플래그 / opacity', val: '✓ 동작', ok: true },
-      { key: 'Concurrent 렌더 분리', val: '✓ 동작', ok: true },
-      { key: 'useMemo 캐시', val: '✗ 항상 재계산', ok: false },
-      { key: '정확성', val: '✓ 보장', ok: true },
-    ]
+      { key: '재활용', val: '\u2717 한 번도 안 됨', ok: false },
+      { key: '화면의 답', val: '\u2713 늘 맞음', ok: true },
+      { key: '잃는 것', val: '속도', ok: false },
+    ],
   },
   {
-    triggers: [
-      { label: 'query 타이핑', queryChange: true, itemsChange: false, deferredChange: false },
-      { label: 'deferred 반영', queryChange: false, itemsChange: false, deferredChange: true },
-      { label: '부모 리렌더', queryChange: false, itemsChange: false, deferredChange: false },
-      { label: 'rawData 변경', queryChange: false, itemsChange: true, deferredChange: true },
+    desc: '부모가 <code>const items = useMemo(() => ..., [rawData])</code> 로 참조를 안정화해 내려보내는 경우',
+    rows: [
+      { label: 'items 참조', cells: ['그대로', '그대로', '새로움', '그대로'] },
+      { label: 'useMemo', cells: ['재활용', '재활용', '다시 계산', '재활용'] },
+      { label: '화면의 답', cells: ['맞음', '맞음', '맞음', '맞음'] },
     ],
     result: [
-      { key: 'isStale 플래그 / opacity', val: '✓ 동작', ok: true },
-      { key: 'Concurrent 렌더 분리', val: '✓ 동작', ok: true },
-      { key: 'useMemo 캐시', val: '✓ 의도대로 동작', ok: true },
-      { key: '정확성', val: '✓ 보장', ok: true },
-    ]
-  }
+      { key: '재활용', val: '\u2713 rawData 바뀔 때만 다시 계산', ok: true },
+      { key: '화면의 답', val: '\u2713 늘 맞음', ok: true },
+      { key: '잃는 것', val: '없음', ok: true },
+    ],
+  },
+  {
+    desc: '참조는 안정한데 계산이 <code>sortAsc</code> 를 쓰면서 재료 목록에는 안 적어둔 경우 — <code>useMemo(() => sort(items, sortAsc), [items])</code>. <strong>무관한 rawData 가 바뀔 때만 우연히 맞아진다</strong> — 이래서 원인을 찾기 어렵다',
+    rows: [
+      { label: 'items 참조', cells: ['그대로', '그대로', '새로움', '그대로'] },
+      { label: 'sortAsc (재료 밖)', cells: ['그대로', '바뀜', '그대로', '바뀜'] },
+      { label: 'useMemo', cells: ['재활용', '재활용', '다시 계산', '재활용'] },
+      { label: '화면의 답', cells: ['맞음', '틀림', '맞음', '틀림'] },
+    ],
+    result: [
+      { key: '재활용', val: '\u2713 잘 됨', ok: true },
+      { key: '화면의 답', val: '\u2717 맞다 틀리다 한다', ok: false },
+      { key: '잃는 것', val: '정확성 — 느린 게 아니라 틀린 것', ok: false },
+    ],
+  },
 ];
 
-const ROWS = ['query', 'deferredQuery', 'items', 'filtered (useMemo)'];
-
-function computeCells(scenario) {
-  const triggers = scenario.triggers;
-  const N = triggers.length;
-  const rows = [];
-
-  // query row
-  rows.push(triggers.map(t => t.queryChange ? 'changed' : null));
-
-  // deferredQuery row
-  rows.push(triggers.map(t => t.deferredChange ? 'stale→changed' : (t.queryChange ? 'stale' : null)));
-
-  // items row
-  rows.push(triggers.map(t => t.itemsChange ? 'changed' : null));
-
-  // filtered row: rerun if items changed OR deferredQuery changed
-  rows.push(triggers.map(t => {
-    if (t.itemsChange || t.deferredChange) return 'rerun';
-    return 'cached';
-  }));
-
-  return rows;
-}
-
-function cellClass(rowIdx, val) {
-  if (rowIdx === 1) {
-    if (val === 'stale') return 'stale';
-    if (val === 'stale→changed') return 'changed';
-  }
-  if (val === 'changed') return 'changed';
-  if (val === 'rerun') return 'rerun';
-  if (val === 'cached') return 'cached';
+function cls(text) {
+  if (text === '새로움' || text === '바뀜') return 'changed';
+  if (text === '다시 계산' || text === '틀림') return 'rerun';
+  if (text === '재활용' || text === '맞음') return 'cached';
   return '';
-}
-
-function cellText(rowIdx, val) {
-  if (!val) return '—';
-  if (rowIdx === 1) {
-    if (val === 'stale') return 'stale';
-    if (val === 'stale→changed') return '반영';
-  }
-  if (val === 'changed') return '변경';
-  if (val === 'rerun') return '재계산';
-  if (val === 'cached') return '캐시';
-  return val;
 }
 
 let activeTab = 0;
@@ -206,41 +175,19 @@ let activeTab = 0;
 function setTab(i) {
   activeTab = i;
   document.querySelectorAll('.tab').forEach((t, idx) => t.classList.toggle('active', idx === i));
-  document.getElementById('desc-0').style.display = i === 0 ? '' : 'none';
-  document.getElementById('desc-1').style.display = i === 1 ? '' : 'none';
   render();
 }
 
 function render() {
   const sc = SCENARIOS[activeTab];
-  const cells = computeCells(sc);
-  const N = sc.triggers.length;
-
-  // tick labels
-  const tickEl = document.getElementById('tick-labels');
-  tickEl.innerHTML = sc.triggers.map(t => `<div class="tick">${t.label}</div>`).join('');
-
-  // timeline
-  const tlEl = document.getElementById('timeline');
-  tlEl.innerHTML = ROWS.map((rowLabel, ri) => {
-    const cellsHtml = cells[ri].map((val, ci) => {
-      const cls = cellClass(ri, val);
-      const txt = cellText(ri, val);
-      return `<div class="cell ${cls}">${txt}</div>`;
-    }).join('');
-    return `<div class="row">
-      <div class="row-label">${rowLabel}</div>
-      <div class="cells">${cellsHtml}</div>
-    </div>`;
+  document.getElementById('desc').innerHTML = sc.desc;
+  document.getElementById('tick-labels').innerHTML = TICKS.map(t => `<div class="tick">${t}</div>`).join('');
+  document.getElementById('timeline').innerHTML = sc.rows.map(r => {
+    const cells = r.cells.map(v => `<div class="cell ${cls(v)}">${v === '그대로' ? '\u2014' : v}</div>`).join('');
+    return `<div class="row"><div class="row-label">${r.label}</div><div class="cells">${cells}</div></div>`;
   }).join('');
-
-  // result
-  const rc = document.getElementById('result-card');
-  rc.innerHTML = sc.result.map(r =>
-    `<div class="result-row">
-      <span class="result-key">${r.key}</span>
-      <span class="badge ${r.ok ? 'ok' : 'bad'}">${r.val}</span>
-    </div>`
+  document.getElementById('result-card').innerHTML = sc.result.map(r =>
+    `<div class="result-row"><span class="result-key">${r.key}</span><span class="badge ${r.ok ? 'ok' : 'bad'}">${r.val}</span></div>`
   ).join('');
 }
 

--- a/src/content/memo/570.mdx
+++ b/src/content/memo/570.mdx
@@ -1,31 +1,35 @@
 ---
 type: note
 kind: Explainer
-tags: ['react', 'usememo', 'usedeferredvalue']
+tags: ['react', 'usedeferredvalue']
 status: release
 ctime: 2026-06-23
-mtime: 2026-08-19
-generated: { by: claude/opus-5, at: 2026-08-19T12:30:00Z }
+mtime: 2026-08-20
+generated: { by: claude/opus-5, at: 2026-08-20T08:30:00Z }
+sources:
+  - id: react-usedeferredvalue
+    resource: https://react.dev/reference/react/useDeferredValue
+    title: "useDeferredValue — React"
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
 
-## useMemo — 적중은 Object.is(deep-equal 아님)
+검색어를 치면 입력창은 바로 바뀌어야 하는데, 아래 무거운 목록까지 매번 다시 그리면 버벅인다. `useDeferredValue(value)`는 같은 값을 **한 박자 늦게 따라오는 짝**으로 하나 더 만들어준다. 입력창은 빠른 쪽을, 무거운 목록은 늦은 쪽을 쓴다.
 
-useMemo 적중 조건은 **`Object.is`(참조/원시 동등)이지 deep-equal이 아니다**. 그래서 인라인 `items={data.map(...)}`은 내용이 같아도 매 렌더 miss(참조가 매번 새로움). 정확성은 별개 — 순수 가정(매 렌더 `f() = φ(deps)`)이 서면 적중이든 miss든 반환값은 항상 fresh `φ(deps)`. stale closure(deps에 없는 변수 포획)는 그 가정 자체를 깨서 stale 값을 낸다.
+그럼 늦은 쪽이 보여주는 값을 믿어도 되나.
 
-<AutoIframe
-  src="/iframe/useMemo_cache_behavior.html"
-  title="useMemo 캐시 매트릭스 — items 안정/불안정에서 재계산 횟수"
-/>
+**어떻게 도는지부터.** 글자를 하나 치면 React가 화면을 **두 번** 그린다. 첫 번째는 빠른 쪽만 새 값으로(`query`는 이미 `"ab"`인데 `deferredQuery`는 아직 `"a"`), 두 번째는 늦은 쪽까지 새 값으로. 두 번째 그리기는 **첫 번째가 끝나자마자** 시작한다 — 기다리는 시간 같은 건 없다. 그리는 도중에 글자를 더 치면 그때까지 그린 걸 버리고 **처음부터 다시** 그린다. 다 그려서 화면에 올리기 전까지는 아무것도 안 보이고 `useEffect`도 안 돈다.[^react-deferred]
 
-## useDeferredValue — items와 무관 (핵심)
+- **없는 값을 만들지 않는다** — 늦은 쪽이 보여주는 건 언제나 _내가 실제로 쳤던 것 중 하나_다. 지어내지 않는다.
+- **결국 따라잡는다** — 손을 멈추면 따라잡는다. 계속 치는 동안은 다시 그리기가 반복해서 취소돼 영영 못 따라잡을 수도 있는데, 고장이 아니라 그러라고 만든 것이다. 그 벌어진 사이가 `isStale`이고, 보통 화면을 흐리게 해서 "아직 옛날 거예요"를 알린다.
 
-`deferred` 궤적은 자기 입력(`query`)에만 의존하고 **`items` 참조 안정성과 무관**(증명이 `rfl`인 이유 — items가 계산에 안 들어감). 그래서 items가 매 렌더 새로 만들어져도 **죽는 건 useMemo 캐시 한 층뿐**, deferred는 안 흔들린다.
+둘 다 위 동작에서 그대로 나온다 — **돌려줄 값을 새로 만드는 일이 없으니** 지어낼 수가 없고, **다시 그리기가 늘 최신 값에서 출발하니** 손을 멈추면 그 그리기가 끝까지 간다. **믿어도 된다. 다만 언제 따라잡을지는 모른다.**
 
-안전성: deferred는 항상 _지금까지 본 입력 중 하나_(미래·날조값 아님). 수렴: 입력이 안정화되고 저우선순위 렌더가 무한 선점 안 되면 따라잡음 — 그 격차 구간이 `isStale`(opacity dim 창). 연속 타이핑 시 영영 못 따라잡을 수 있는데 버그가 아니라 의도(그 내내 dim 유지).
+**목록을 인라인으로 만들어도 늦은 쪽은 안 흔들린다.** `items={data.map(...)}`처럼 써서 참조가 매번 새로 생겨도 상관없다 — 그 목록이 늦은 쪽 계산에 아예 안 들어가기 때문이다. 같은 상황에서 망가지는 건 useMemo 캐시 쪽이다 → [578](/memo/578)
 
 <AutoIframe
   src="/iframe/two_clocks_deferred_vs_immediate.html"
-  title="useDeferredValue — immediate(urgent) vs deferred, 둘의 격차가 isStale 구간"
+  title="입력을 곧바로 따라가는 값과 뒤처지는 값의 두 시간축, 둘이 어긋난 구간이 isStale"
 />
+
+[^react-deferred]: 두 단계 — *"First, React re-renders with the new `query` (`"ab"`) but with the old `deferredQuery` (still `"a"`) … In the background, React tries to re-render with **both** `query` and `deferredQuery` updated."* / 타이밍 — *"There is no fixed delay caused by `useDeferredValue` itself. As soon as React finishes the original re-render, React will immediately start working on the background re-render."* / 중단 — *"The background re-render is interruptible: if there's another update to the value, React will restart the background re-render from scratch."* / Effect — *"does not fire Effects until it's committed to the screen."* ([useDeferredValue — React](https://react.dev/reference/react/useDeferredValue))

--- a/src/content/memo/578.mdx
+++ b/src/content/memo/578.mdx
@@ -1,0 +1,36 @@
+---
+type: note
+kind: Explainer
+tags: ['react', 'usememo']
+status: release
+ctime: 2026-06-23
+mtime: 2026-08-20
+generated: { by: claude/opus-5, at: 2026-08-20T10:00:00Z }
+parent: '570'
+sources:
+  - id: react-usememo
+    resource: https://react.dev/reference/react/useMemo
+    title: "useMemo — React"
+---
+
+import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
+
+목록을 걸러내거나 정렬하는 계산이 무거우면 매 렌더마다 다시 하기 아깝다. `useMemo`는 **지난번 결과를 기억해뒀다가, 재료가 그대로면 그걸 다시 쓰는** 것이다.
+
+문제는 "재료가 그대로"를 어떻게 판단하느냐다. React는 재료 **안을 들여다보지 않는다** — `Object.is`로 *같은 물건인지*만 본다.[^react-usememo] 내용이 똑같은 배열이라도 매번 새로 만들면 다른 물건으로 친다.
+
+그래서 `items={data.map(...)}`처럼 인라인으로 넘기면 **한 번도 재활용되지 않는다.** 렌더마다 새 배열이 생기니까.
+
+**그래도 화면이 틀리지는 않는다.** 재활용을 못 하면 다시 계산할 뿐이고, **같은 재료로 늘 같은 답을 내는 계산**이라면 답은 똑같다. 잃는 건 속도뿐이다. React가 이 전제를 얼마나 중요하게 보는지는 개발 모드에서 드러난다 — 계산 함수를 **일부러 두 번 불러서** 답이 달라지는지 확인한다.
+
+그 "늘 같은 답" 전제가 깨지는 경우가 둘 있다.
+
+- **재료 목록(`deps`)에 안 적어둔 값을 계산 안에서 쓰면**(stale closure) — 그 값이 바뀌어도 React는 "재료 그대로"로 보고 **옛날 답을 내놓는다.** 느린 게 아니라 틀린 것이다. 게다가 무관한 재료가 바뀌는 순간 **우연히 맞아졌다가 다시 틀린다** — 그래서 원인을 찾기 어렵다.
+- **계산이 매번 다른 답을 내면**(랜덤 같은 것) — React는 특별한 이유가 있으면 기억해둔 걸 버리는데, 그 순간 답이 바뀐다 → [574](/memo/574)
+
+<AutoIframe
+  src="/iframe/useMemo_cache_behavior.html"
+  title="items 참조가 안정할 때와 매 렌더 새로 만들어질 때의 재계산 횟수 비교"
+/>
+
+[^react-usememo]: *"React will compare each dependency with its previous value using the `Object.is` comparison."* / *"React will not throw away the cached value unless there is a specific reason to do that … This should be fine if you rely on `useMemo` solely as a performance optimization."* / *"In Strict Mode, React will call your calculation function twice in order to help you find accidental impurities."* ([useMemo — React](https://react.dev/reference/react/useMemo))


### PR DESCRIPTION
두 훅이 한 메모에 있었는데 연결이 **부정형 한 줄**뿐이었다 — *"useMemo는 망가지고 deferred는 안 망가진다."* 서로를 설명하지 않고, 시뮬레이터도 링크도 각자 갖는다. `575`가 `570`을 가리키는 것도 deferred 쪽 **절반**이다.

```
570  useDeferredValue   ← 575 의 인바운드 링크를 지키려고 여기 남김
578  useMemo            parent: '570'
570 → 578               실제 관계 한 줄은 교차 링크로
```

## 초등학생 눈높이 — "왜 쓰는지"가 통째로 빠져 있었다

쉽게 쓰려니 구멍이 바로 드러났다. 둘 다 **첫 문단이 새로 생겼다.**

| | 전 (바로 기제로 진입) | 후 (왜부터) |
|---|---|---|
| `570` | deferred 값은 입력을 뒤따라간다 | 무거운 목록까지 매번 다시 그리면 버벅인다 → **한 박자 늦게 따라오는 짝**을 만들어준다 |
| `578` | 적중 조건은 `Object.is`이지 deep-equal이 아니다 | 계산이 무거우면 매 렌더마다 다시 하기 아깝다 → **지난번 결과를 기억해뒀다 재활용** |

풀어쓴 용어: 적중/miss → 재활용, deep-equal → *"안을 들여다보지 않는다"*, 순수 함수 → *"같은 재료로 늘 같은 답"*, 포획 → *"안 적어둔 값을 계산 안에서 쓰면"*, 안전성/수렴 → *"없는 값을 만들지 않는다"* / *"결국 따라잡는다"*.

`Object.is`·`deps`·`stale closure`는 검색 가능한 손잡이로 남겼다.

## 문제-증명 구조

- **570** — *"뒤처진 값을 믿어도 되나"* → 두 사실 → **그 둘이 왜 동작에서 곧장 나오는지** → *"믿어도 된다. 다만 언제 따라잡을지는 모른다"*
- **578** — *"인라인으로 넘기면 무엇이 망가지나"* → *"속도만, 단 전제가 설 때"* → 전제가 깨지는 둘

## 출처 — react.dev 로 검증, 각주에 인용

**useDeferredValue**: 두 단계 렌더 / *"There is no fixed delay… **as soon as React finishes the original re-render**"* / *"restart the background re-render **from scratch**"* / 커밋 전엔 Effect 안 돔

**useMemo**: *"compare each dependency… using the `Object.is` comparison"* / *"rely on `useMemo` **solely as a performance optimization**"* / *"In Strict Mode, React will **call your calculation function twice**"*

> 문서가 "Transition"이나 "저우선순위"라고 말하지 않으므로 원문의 *"저우선순위 렌더가 무한 선점"* 표현은 뺐다.

## 시뮬레이터도 같이 분리

`useMemo_cache_behavior`가 **570의 내용을 들고 있었다** — `deferredQuery` 행, `isStale 플래그`, `Concurrent 렌더 분리`. 그리고 결과 카드가 `정확성 ✓ 보장`을 **무조건 단언**해 메모의 반대를 말하고 있었다.

- deferred 관련 행·결과 제거
- 탭 3개로 재구성: **items를 매번 새로 만들면** / **참조가 그대로면** / **재료에 안 적어둔 값을 쓰면**
- **`화면의 답` 행 추가** — 앞의 둘은 느려질 뿐 답이 맞고, 마지막만 틀린다. 메모의 핵심(*"느린 게 아니라 틀린 것"*)이 그림에서 보인다
- stale closure 탭은 **무관한 재료가 바뀔 때 우연히 맞아졌다 다시 틀리는 것**까지 보여준다 → 그 간헐성을 `578` 본문에도 한 구절 넣었다
- `sr-only` 제목 추가 (이 시뮬레이터에만 없었다)

## 검증

- `pnpm lint:memo` — 540개, 오류 0 · 경고 0
- `astro build` — 783페이지
- 시뮬레이터 JS 문법 검사 + 세 탭 데이터·색 매핑 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
