### PR TITLE
memo: 574 주장 명확화 + useMemo 3부작 OKF 필드 정리

### DIFF
--- a/src/content/memo/570.mdx
+++ b/src/content/memo/570.mdx
@@ -6,6 +6,7 @@ status: release
 ctime: 2026-06-23
 mtime: 2026-08-20
 generated: { by: claude/opus-5, at: 2026-08-20T08:30:00Z }
+verified: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
 sources:
   - id: react-usedeferredvalue
     resource: https://react.dev/reference/react/useDeferredValue

--- a/src/content/memo/574.mdx
+++ b/src/content/memo/574.mdx
@@ -1,5 +1,6 @@
 ---
 type: snippet
+kind: Convention
 tags:
   [
     'react',
@@ -11,16 +12,27 @@ tags:
   ]
 status: release
 ctime: 2026-06-23
-mtime: 2026-06-23
+mtime: 2026-08-21
+generated: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+verified: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+sources:
+  - id: react-usememo
+    resource: https://react.dev/reference/react/useMemo
+    title: "useMemo — React (caveats)"
+  - id: shud-thoughts-build-bulletproof
+    resource: https://shud.in/thoughts/build-bulletproof-react-components
+    title: "Building Bulletproof React Components — Shu Ding"
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
 
-**`useMemo`는 성능 힌트지 의미적 보장이 아니다 — 정확성을 캐시에 의존하면 안 된다.** React는 특별한 이유가 있으면 캐시를 버린다: 개발 중 HMR, 초기 마운트 중 suspend, 미래 기능(오프스크린/가상 리스트). 그래서 `useMemo` 결과로 "한 번 정해지면 유지돼야 하는 값"을 만들면, 캐시가 폐기되는 순간 값이 바뀐다.
+**`useMemo`가 보장하는 건 "값이 맞다"이지 "같은 값이 유지된다"가 아니다.** React는 특별한 이유가 있으면 캐시를 버린다 — 개발 중 파일을 고칠 때, 초기 마운트 중 컴포넌트가 suspend할 때, 그리고 앞으로 나올 기능(가상 리스트에서 화면 밖으로 스크롤된 항목 같은 것).
+
+계산이 순수하면 버려져도 같은 답이 나오니 상관없다. **매번 다른 답을 내는 계산**을 넣었을 때만 문제가 된다 — 캐시가 버려지는 순간 값이 바뀐다.
 
 <AutoIframe
   src="/iframe/usememo_cache_discard.html"
-  title="useMemo vs useState — 캐시 폐기 이벤트를 던지면 useMemo만 색이 바뀐다(flicker)"
+  title="캐시 폐기 이벤트를 던지면 useMemo 쪽만 색이 다시 뽑혀 튀고, useState 쪽은 그대로다"
 />
 
 ```tsx
@@ -39,6 +51,8 @@ if (baseTheme !== prevTheme) {
 
 판별 기준: "이 값이 재계산되면 _틀린_ 동작인가, 아니면 그냥 _느린_ 동작인가."
 틀림 → state/ref. 느림 → useMemo.
+
+재활용 자체가 안 되는 쪽(참조가 매 렌더 새로워지는 경우)은 속도 문제일 뿐이다 → [578](/memo/578)
 
 ## 참고
 

--- a/src/content/memo/578.mdx
+++ b/src/content/memo/578.mdx
@@ -6,6 +6,7 @@ status: release
 ctime: 2026-06-23
 mtime: 2026-08-20
 generated: { by: claude/opus-5, at: 2026-08-20T10:00:00Z }
+verified: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
 parent: '570'
 sources:
   - id: react-usememo


### PR DESCRIPTION
*"useMemo는 성능 힌트지 의미적 보장이 아니다"*가 **"반환값을 믿을 수 없다"**로 읽힐 수 있었다. 그건 사실이 아니고 #35 에서 쓴 `578` 과 정면으로 충돌한다.

| | 주장 |
|---|---|
| `578` | 재활용을 못 해도 **답은 맞다.** 잃는 건 속도 |
| `574` (전) | 의미적 **보장이 아니다** ← 답을 못 믿는다는 뜻으로 읽힘 |
| `574` (후) | **값은 맞다. 같은 값이 유지되지 않을 뿐** |

## 무엇을 보장하고 무엇을 안 하는지를 나란히

```
전 : useMemo는 성능 힌트지 의미적 보장이 아니다 — 정확성을 캐시에 의존하면 안 된다.
후 : useMemo가 보장하는 건 "값이 맞다"이지 "같은 값이 유지된다"가 아니다.
```

전 문장은 "보장이 아니다"만 말해서 **무엇이 보장 안 되는지를 독자가 채워 넣어야 했다.**

## 실패 조건도 구체화

```
전 : "한 번 정해지면 유지돼야 하는 값"을 만들면
후 : 매번 다른 답을 내는 계산을 넣었을 때만 문제가 된다
```

`578` 의 *"같은 재료로 늘 같은 답"* 전제와 같은 말이 된다.

## 문서 표현으로 맞춘 것

| 전 | 후 (react.dev) |
|---|---|
| 개발 중 HMR | 개발 중 **파일을 고칠 때** |
| 미래 기능(오프스크린/가상 리스트) | **가상 리스트에서 화면 밖으로 스크롤된 항목** 같은 것 |

원문: *"if React adds built-in support for virtualized lists… it would make sense to throw away the cache for **items that scroll out of the virtualized table viewport**."*

## 링크·용어

- **`574` → `578` 역방향 링크 추가.** 전에는 `578` → `574` 한 방향뿐이라 `574`에서 읽기 시작하면 짝을 못 찾았다
- `AutoIframe` `title` 의 `flicker` 제거 — `573`이 그 단어를 스피너 타이밍 의미로 쓰고 있어 충돌하던 자리

## OKF 필드

- **`574`** — `kind: Convention` · `generated` · `verified` · `sources` 추가. `snippet` 이라 #28 note 배치에서 빠져 있었다. 본문 `## 참고` 의 링크 둘을 `sources` 로 전사하고, 화면에 보이는 참고 목록은 그대로 둔다
- **`570`·`578`** — `verified` 추가. #35 에서 각주로 인용까지 넣어놓고 기록만 빠져 있었다

검증 깊이: react.dev 는 주장 대조(캐시 폐기 사유·`Object.is`·Strict Mode 이중 호출·두 단계 렌더), Shu Ding 글은 링크 생존만 확인.

## 검증

- `pnpm lint:memo` — 540개, 오류 0 · 경고 0
- `astro build` — 783페이지
- `lint:links 574` — 죽은 링크 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
