### PR TITLE
memo: 574 주인공을 useState 로

### DIFF
--- a/src/content/memo/574.mdx
+++ b/src/content/memo/574.mdx
@@ -4,6 +4,7 @@ kind: Convention
 tags:
   [
     'react',
+    'usestate',
     'usememo',
     'derived-state',
     'cache-discard',
@@ -19,6 +20,9 @@ sources:
   - id: react-usememo
     resource: https://react.dev/reference/react/useMemo
     title: "useMemo — React (caveats)"
+  - id: react-usestate
+    resource: https://react.dev/reference/react/useState
+    title: "useState — React"
   - id: shud-thoughts-build-bulletproof
     resource: https://shud.in/thoughts/build-bulletproof-react-components
     title: "Building Bulletproof React Components — Shu Ding"
@@ -26,33 +30,35 @@ sources:
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
 
-**`useMemo`가 보장하는 건 "값이 맞다"이지 "같은 값이 유지된다"가 아니다.** React는 특별한 이유가 있으면 캐시를 버린다 — 개발 중 파일을 고칠 때, 초기 마운트 중 컴포넌트가 suspend할 때, 그리고 앞으로 나올 기능(가상 리스트에서 화면 밖으로 스크롤된 항목 같은 것).
-
-계산이 순수하면 버려져도 같은 답이 나오니 상관없다. **매번 다른 답을 내는 계산**을 넣었을 때만 문제가 된다 — 캐시가 버려지는 순간 값이 바뀐다.
+테마에서 뽑은 강조색처럼 **한 번 정해지면 유지돼야 하는 값**은 `useMemo`에 두면 안 된다. `useMemo`가 보장하는 건 "값이 맞다"이지 **"같은 값이 유지된다"가 아니다.** React는 특별한 이유가 있으면 캐시를 버린다 — 개발 중 파일을 고칠 때, 초기 마운트 중 컴포넌트가 suspend할 때, 앞으로 나올 기능(가상 리스트에서 화면 밖으로 스크롤된 항목 같은 것). 계산이 순수하면 버려져도 같은 답이 나오니 상관없지만, 랜덤처럼 **매번 다른 답을 내는 계산**이면 버려지는 순간 색이 바뀐다.
 
 <AutoIframe
   src="/iframe/usememo_cache_discard.html"
   title="캐시 폐기 이벤트를 던지면 useMemo 쪽만 색이 다시 뽑혀 튀고, useState 쪽은 그대로다"
 />
 
-```tsx
-// ❌ 캐시 폐기 시 색이 재생성 → flicker
-const colors = useMemo(() => getRandomColors(baseTheme), [baseTheme])
+그래서 `useState`에 둔다. 여기에 놓치기 쉬운 게 둘 있다.
 
-// ✅ 영속성이 정확성 조건이면 state로
+```tsx
 const [colors, setColors] = useState(() => generateAccentColors(baseTheme))
 const [prevTheme, setPrevTheme] = useState(baseTheme)
+
 if (baseTheme !== prevTheme) {
-  // 렌더 중 prev 비교 = derived state
   setPrevTheme(baseTheme)
   setColors(generateAccentColors(baseTheme))
 }
 ```
 
+**1. `useState(() => ...)` — 괄호를 붙이지 않는다.** `useState(generateAccentColors(baseTheme))`라고 쓰면 함수가 **매 렌더마다 돌고** 결과는 첫 렌더 말고는 전부 버려진다. 함수 자체를 넘기면 React가 처음 한 번만 부른다.[^react-usestate]
+
+**2. 테마가 바뀌면 렌더 중에 갈아끼운다.** `if (이전 값 !== 지금 값)` 안에서 이전 값을 갱신하고 새 값을 만든다. 이 모양이어야 하는 이유가 있다 — React는 렌더 중 `set`을 보면 `return` 직후 **화면에 그리기 전에** 그 컴포넌트만 다시 렌더한다(자식은 두 번 안 그린다). 그래서 깜빡임이 없다. 다만 **조건이나 `setPrevTheme` 중 하나라도 빠지면 무한 루프로 터진다.**[^react-usestate]
+
 판별 기준: "이 값이 재계산되면 _틀린_ 동작인가, 아니면 그냥 _느린_ 동작인가."
 틀림 → state/ref. 느림 → useMemo.
 
 재활용 자체가 안 되는 쪽(참조가 매 렌더 새로워지는 경우)은 속도 문제일 뿐이다 → [578](/memo/578)
+
+[^react-usestate]: 게으른 초기화 — *"Although the result of `createInitialTodos()` is only used for the initial render, you're still calling this function on every render … If you pass a function to `useState`, React will only call it during initialization."* / 렌더 중 `set` — *"React will re-render that component immediately after your component exits with a `return` statement, and before rendering the children."* / 필수 조건 — *"it must be inside a condition like `prevCount !== count`, and there must be a call like `setPrevCount(count)` inside of the condition. Otherwise, your component would re-render in a loop until it crashes."* ([useState — React](https://react.dev/reference/react/useState))
 
 ## 참고
 


### PR DESCRIPTION
`useMemo` 의 caveats 로 시작하는데, **실제로 쓰는 것은 `useState(() => ...)` 와 렌더 중 derived state 쪽**이다. `tags` 는 이미 `derived-state`·`render-time-setstate` 를 달고 있었는데 본문이 그걸 안 다뤘다.

```
전 : useMemo는 이런 보장을 안 한다 → (코드) → 판별 기준
후 : 유지돼야 하는 값을 어디 둘까 → useMemo가 안 되는 이유 → useState에 두되
     놓치기 쉬운 게 둘 → 판별 기준
```

`useMemo` 는 이제 **반례**다.

## 코드에만 있고 설명이 없던 둘

**1. `useState(() => ...)` 의 화살표**

> `useState(generateAccentColors(baseTheme))` 라고 쓰면 함수가 **매 렌더마다 돌고** 결과는 첫 렌더 말고는 전부 버려진다.

전 판본은 이 화살표가 왜 있는지 **한 번도 말하지 않았다.**

**2. `if (이전 !== 지금)` 모양이 필수라는 것**

> React 는 렌더 중 `set` 을 보면 `return` 직후 **화면에 그리기 전에** 그 컴포넌트만 다시 렌더한다(자식은 두 번 안 그린다). 그래서 깜빡임이 없다. 다만 **조건이나 `setPrevTheme` 중 하나라도 빠지면 무한 루프로 터진다.**

전에는 `// 렌더 중 prev 비교 = derived state` 주석 한 줄이라 **취향이 아니라 필수**라는 게 안 드러났다.

## 출처 — react.dev useState 추가

| 주장 | 인용 |
|---|---|
| 괄호 붙이면 매 렌더 실행 | *"you're still calling this function on every render … If you pass a function to `useState`, React will only call it during initialization."* |
| 렌더 중 `set` → 그리기 전 재렌더 | *"re-render that component immediately after your component exits with a `return` statement, and before rendering the children."* |
| 조건·갱신 없으면 무한 루프 | *"Otherwise, your component would re-render in a loop until it crashes."* |

`tags` 에 `usestate` 추가 (빌드 783 → 784페이지, 태그 페이지 1개 증가).

## 검증

- `pnpm lint:memo` — 540개, 오류 0 · 경고 0
- `astro build` — 784페이지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
