### PR TITLE
memo: 569 가설-반증 구조로, 568 주어 복원

### DIFF
--- a/src/content/memo/568.mdx
+++ b/src/content/memo/568.mdx
@@ -1,20 +1,41 @@
 ---
 type: note
 kind: Explainer
-tags: ['probability', 'coupon-collector', 'math']
+tags: ['claude-code', 'probability', 'coupon-collector', 'math']
 status: release
 ctime: 2026-06-23
-mtime: 2026-06-27
-generated: { by: claude/opus-4.8, at: 2026-06-28T14:49:32Z }
+mtime: 2026-08-21
+generated: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+verified: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+sources:
+  - id: wikipedia-coupon-collector
+    resource: https://en.wikipedia.org/wiki/Coupon_collector%27s_problem
+    title: "Coupon collector's problem — Wikipedia"
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
 
-spinner 메시지가 매 틱 **셔플이 아니라 독립 균등추출(복원)**이면, 체감 "다양함"의 한계는 coupon collector 꼬리다 — 풀 n(≈90)을 다 보려면 평균 `nH_n` ≈ **7.6분**, 마지막 한 단어가 제일 오래 걸린다. 셔플이었다면 정확히 n틱에 끝났을 것 — 복원추출이라 꼬리가 생긴다.
+Claude Code가 일하는 동안 스피너 옆에 단어가 하나씩 뜬다. 목록은 90개쯤 되고 매 초 바뀐다고 하자. **90개를 다 보려면 90초쯤 걸릴까.**
+
+아니다. **평균 7분 반**이 걸린다. 5배다.
+
+목록을 한 번 섞어서 처음부터 끝까지 도는 게 아니라 **매번 90개 중에서 새로 뽑기** 때문이다. 그러면 이미 본 단어가 계속 다시 나온다. 섞어 돌았다면 90초에 정확히 끝났을 일이다.
+
+**꼬리가 어디서 생기는지가 핵심이다.** 89개를 모았을 때, 남은 마지막 하나를 뽑을 확률은 90분의 1이다. 그 **한 단어를 만나는 데만 평균 90초** — 섞어서 돌았다면 90개 전부를 봤을 시간이다.[^wikipedia-coupon-collector]
+
+이게 쿠폰 수집가 문제(coupon collector)다. 전부 모으는 데 걸리는 평균 횟수는
+
+```
+n × (1 + 1/2 + 1/3 + … + 1/n)
+```
+
+`n = 90`이면 약 457번, 매 초 하나씩이니 7.6분이다.
 
 <AutoIframe
   src="/iframe/spinner_coupon_collector_explorer.html"
-  title="spinner coupon collector explorer — 풀 크기에 따른 기대 누적 unique 곡선"
+  title="목록 크기를 바꿔가며, 시간이 지날수록 서로 다른 단어를 몇 개나 보게 되는지 보여주는 곡선"
 />
 
-탐색기: 풀 크기 슬라이더로 기대 누적 unique 곡선 — 커스텀 단어를 append할수록 분모가 커져 빌트인 단어 확률이 희석된다.
+곁가지 — 커스텀 단어를 덧붙이면 목록이 길어지니 **빌트인 단어가 뽑힐 확률은 그만큼 낮아진다.** 다양해 보이려고 추가한 게 원래 있던 것들을 밀어낸다.
+
+[^wikipedia-coupon-collector]: 전부 모으는 기대 횟수는 `n·H_n`(`H_n`은 조화수). 그리고 `i`번째 새 쿠폰까지의 기대 대기는 `n/(n-i+1)` 이므로 **마지막 한 장은 `n/1 = n`** — 단계 중 가장 오래 걸린다. ([Coupon collector's problem — Wikipedia](https://en.wikipedia.org/wiki/Coupon_collector%27s_problem))

--- a/src/content/memo/569.mdx
+++ b/src/content/memo/569.mdx
@@ -4,24 +4,33 @@ kind: Explainer
 tags: ['javascript', 'event-loop', 'navigation']
 status: release
 ctime: 2026-06-23
-mtime: 2026-06-23
-generated: { by: claude/opus-4.8, at: 2026-06-28T14:49:32Z }
+mtime: 2026-08-21
+generated: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+verified: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+sources:
+  - id: html-spec-navigate
+    resource: https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
+    title: "HTML Standard — navigate"
 ---
 
-<img
-  src="/svg/event_loop_nav_slot.svg"
-  alt="location.href setter 실행 시점(②)과 실제 navigation 처리 시점(④)이 분리되는 이벤트 루프 타임라인"
-/>
-
-**`location.href` setter의 실행 시점과 실제 navigation 처리 시점은 분리된다.** setter는 동기적으로 정상 실행되지만(흐름을 끊지 않음), 그 효과는 브라우저 슬롯에 "마지막 값으로 덮어쓰기"로만 남는다. 실제 이동은 콜 스택이 비고 마이크로태스크까지 소진된 뒤(④)에야 일어난다.
-
-그래서 "암묵적 await" 가설은 틀렸다 — await였다면 첫 줄에서 멈춰 `google.com`으로 갔겠지만, 실제로는 두 setter가 모두 실행되고 마지막 값 `google2.com`으로 간다.
+`location.href`에 값을 넣으면 그 줄에서 페이지가 떠날 것 같다. 마치 **암묵적 `await`**처럼 거기서 멈춘다고 생각하기 쉽다. 그럼 뒤에 오는 코드는 안 도는 걸까.
 
 ```js
 location.href = 'https://google.com'
-console.log('실행됨 1') // 출력됨
+console.log('실행됨 1')
 location.href = 'https://google2.com'
-console.log('실행됨 2') // 출력됨 → await였다면 안 찍힘
+console.log('실행됨 2')
 ```
 
-두 `console.log`가 모두 찍히는 것이 setter가 흐름을 끊지 않는다는 직접 증거다.
+**둘 다 찍힌다. 그리고 이동은 `google2.com`으로 간다.**
+
+`await`였다면 첫 줄에서 멈춰 `실행됨 1`도 안 찍히고 `google.com`으로 갔어야 한다. 두 결과가 모두 어긋나니 가설은 틀렸다.
+
+실제로는 이렇다. setter는 **동기적으로 정상 실행되고 흐름을 끊지 않는다.** 문서를 내리고 네트워크를 타는 실제 작업은 태스크로 넘어가 지금 돌고 있는 코드가 끝난 뒤에 시작된다. 그리고 두 번째 navigation이 시작되면 **진행 중이던 첫 번째가 버려진다**[^html-spec-navigate] — 마지막 값이 이기는 건 덮어써서가 아니라 앞의 것이 취소되기 때문이다.
+
+<img
+  src="/svg/event_loop_nav_slot.svg"
+  alt="location.href setter가 실행되는 시점과 실제 navigation이 처리되는 시점이 분리되는 이벤트 루프 타임라인"
+/>
+
+[^html-spec-navigate]: *"Set the ongoing navigation for navigable to navigationId. This will have the effect of **aborting other ongoing navigations** of navigable, since at certain points during navigation changes to the ongoing navigation will cause further work to be abandoned."* — 그리고 문서 언로드·페치는 `in parallel` 로 넘어간다. ([HTML Standard — navigate](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate))


### PR DESCRIPTION
둘 다 **맥락이 본문이 아니라 시각 자료에만 있던** 경우다.

## 569 — 순서를 뒤집는다

이미 반증 구조가 잠재해 있었는데(*"암묵적 await 가설은 틀렸다"*, *"두 `console.log`가 직접 증거다"*) **답을 먼저 말하고 나중에 가설을 소개**해서 안 보였다.

```
전 : 다이어그램 → 결론(분리된다) → 가설이 틀렸다 → 코드 → 증거다
후 : 가설 → 실험 → 결과 → 반증 → 그럼 실제로는 → 다이어그램
```

반증을 두 갈래로 갈랐다 — `await`였다면 `실행됨 1`도 **안 찍혔어야** 하고 `google.com`으로 **갔어야** 한다. 둘 다 어긋난다.

### 모델 하나를 고쳤다

```
전 : 그 효과는 브라우저 슬롯에 "마지막 값으로 덮어쓰기"로만 남는다
후 : 두 번째 navigation이 시작되면 진행 중이던 첫 번째가 버려진다
```

> HTML Standard: *"Set the ongoing navigation for navigable to navigationId. This will have the effect of **aborting other ongoing navigations**…"*

**맞는 답을 틀린 이유로 설명**하고 있었다. 관찰(마지막 것이 이긴다)은 같지만 기제가 다르다.

`마이크로태스크까지 소진된 뒤(④)`도 뺐다 — 스펙은 `in parallel`과 태스크 큐로 말하지 마이크로태스크 체크포인트를 명시하지 않는다.

> MDN `Location.href`는 타이밍을 **아예 말하지 않아**(*"Setting the value of href navigates to the provided URL"*가 전부) 스펙으로 갔다.

## 568 — 주어가 없었다

*"spinner 메시지가 매 틱 셔플이 아니라 독립 균등추출(복원)이면"* 으로 시작하는데 **어느 스피너인지가 본문에 한 번도 없다.** 맥락은 시뮬레이터의 `sr-only` 텍스트에만 있었다:

> *"Interactive explorer of the **Claude Code spinner** as a coupon collector problem"*

| 전 | 후 |
|---|---|
| spinner 메시지가 매 틱 **독립 균등추출(복원)**이면 | Claude Code 스피너 옆 단어. 목록을 섞어 도는 게 아니라 **매번 90개 중에서 새로 뽑기** |
| 평균 `nH_n` ≈ 7.6분 | `n × (1 + 1/2 + … + 1/n)`, n=90이면 약 457번, 매 초 하나씩이니 7.6분 |
| **coupon collector 꼬리** | 89개를 모았을 때 남은 하나를 뽑을 확률은 90분의 1 |
| 마지막 한 단어가 제일 오래 걸린다 | **그 한 단어에만 평균 90초** — 섞어 돌았다면 90개 전부를 봤을 시간 |

### 검산

- `H₉₀ ≈ 5.083` → `90 × 5.083 ≈ 457초 = 7.6분` ✓ 원문 숫자와 일치. **여기서 틱이 1초라는 게 역산된다**(원문엔 없던 정보)
- 마지막 한 장의 기대 대기 `= n/1 = n` = 90초 ✓ Wikipedia 확인

출처에 Wikipedia coupon collector 추가, `tags`에 `claude-code` 추가.

## 검증

- `pnpm lint:memo` — 540개, 오류 0 · 경고 0
- `astro build` — 785페이지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
