### PR TITLE
memo: 552 를 ngrok 대비 구조로 + 다이어그램에 Sandbox 라벨

### DIFF
--- a/public/iframe/vgrok-reverse-tunnel.html
+++ b/public/iframe/vgrok-reverse-tunnel.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>vgrok — 역방향 영속 연결 (다이어그램)</title>
+<title>vgrok — 내가 먼저 걸어두고 끊지 않는다</title>
 <style>
   :root{
     --font-mono:ui-monospace,"SF Mono",Menlo,Monaco,"Cascadia Code",Consolas,monospace;
@@ -43,6 +43,9 @@
   .pipe.up{opacity:.5}
   .pipelbl{font-size:9px;fill:var(--dim);font-family:var(--font-mono)}
   .pipelbl.up{fill:var(--green)}
+  .sandbox{fill:#151033;stroke:#a78bfa;stroke-width:1.2;stroke-dasharray:4 3;opacity:.9}
+  .sblbl{font-size:9px;fill:#c4b5fd;font-family:var(--font-mono)}
+  .sbsub{font-size:8.5px;fill:#8b7fd4;font-family:var(--font-mono)}
   .conn{stroke:#2a3346;stroke-width:1.6;fill:none}
   .active{stroke-width:3;fill:none}
   .dot{r:5}
@@ -53,9 +56,9 @@
 </head>
 <body>
 <div class="wrap">
-<h1>vgrok — 터널링의 핵심은 역방향 영속 연결</h1>
-<p class="sub">WS는 local이 <b>위로(outbound)</b> 깔지만, 요청은 그 위로 <b>아래로(역방향)</b> 흐른다. ▶로 따라가 보세요</p>
-<h2 class="sr-only">공개 머신(server.js)과 NAT 뒤 local(client.js)을 잇는 WebSocket을 local이 outbound로 열고, 외부 HTTP 요청이 그 연결 위로 역방향으로 흘러 localhost에 닿는 구조를 화살표 다이어그램으로 단계별로 보여주는 explorer. 직접 연결은 NAT inbound 차단으로 실패함도 비교.</h2>
+<h1>vgrok — 내가 먼저 걸어두고 끊지 않는다</h1>
+<p class="sub">연결은 <b>내 컴퓨터가 먼저</b> 열고, 요청은 그 위로 <b>거꾸로</b> 흐른다. 공개 머신 자리엔 <b>잠깐 빌린 Vercel Sandbox</b>가 들어간다. ▶로 따라가 보세요</p>
+<h2 class="sr-only">내 컴퓨터가 먼저 연 WebSocket 위로 외부 HTTP 요청이 거꾸로 흘러 localhost에 닿는 구조를 단계별로 보여주는 다이어그램. 공개 머신 자리에는 잠깐 빌린 Vercel Sandbox가 들어가고 그 안에서 server.js 가 돈다. 터널 없이 직접 들어오려 하면 막히는 경우도 비교한다.</h2>
 
 <div class="controls">
   <button class="go" id="step">▶ 단계</button>
@@ -78,10 +81,10 @@
 
   // 좌표
   const BOX={
-    external:{x:24, y:46, label:'external', sub:'외부 client'},
-    server:  {x:386,y:46, label:'server.js', sub:'공개 머신 · HTTPS'},
-    client:  {x:386,y:262,label:'client.js', sub:'local (NAT 뒤)'},
-    localhost:{x:24,y:262,label:'localhost:3000', sub:'실제 로컬 서버'},
+    external:{x:24, y:46, label:'외부 브라우저', sub:'요청하는 쪽'},
+    server:  {x:386,y:46, label:'server.js', sub:'공개 HTTPS 주소'},
+    client:  {x:386,y:262,label:'client.js', sub:'내 컴퓨터'},
+    localhost:{x:24,y:262,label:'localhost:3000', sub:'진짜 내 서버'},
   };
   const W=150,H=46;
   const cx=b=>b.x+W/2, cy=b=>b.y+H/2;
@@ -102,11 +105,11 @@
 
     // zone labels
     g.appendChild(txt(30,28,'▼ 공개 인터넷','zlbl'));
-    g.appendChild(txt(30,NATY+22,'▼ NAT 뒤 (local)','zlbl'));
+    g.appendChild(txt(30,NATY+22,'▼ 내 컴퓨터 쪽','zlbl'));
 
     // NAT line
     g.appendChild(E('line',{id:'natline',class:'nat',x1:14,y1:NATY,x2:546,y2:NATY}));
-    g.appendChild(txt(280,NATY-5,'NAT / 방화벽 — inbound ✗ · outbound ✓','natlbl',{id:'natlbl','text-anchor':'middle'}));
+    g.appendChild(txt(280,NATY-5,'NAT · 방화벽 — 들어오는 건 ✗, 나가는 건 ✓','natlbl',{id:'natlbl','text-anchor':'middle'}));
 
     // WS pipe (server ↔ client)
     g.appendChild(E('line',{id:'pipe',class:'pipe',x1:PIPEX,y1:BOX.server.y+H,x2:PIPEX,y2:BOX.client.y}));
@@ -119,6 +122,11 @@
     // active path + dot (on top)
     g.appendChild(E('polyline',{id:'act',class:'active',points:'',fill:'none',stroke:'none'}));
     g.appendChild(E('circle',{id:'dot',class:'dot',cx:-20,cy:-20,fill:'#fff',opacity:0}));
+
+    // Vercel Sandbox 컨테이너 — server.js 는 이 안에서 돈다
+    g.appendChild(E('rect',{class:'sandbox',x:372,y:10,width:178,height:96,rx:10}));
+    g.appendChild(txt(461,24,'Vercel Sandbox','sblbl',{'text-anchor':'middle'}));
+    g.appendChild(txt(461,36,'잠깐 빌린 컴퓨터 · 주소가 딸려 온다','sbsub',{'text-anchor':'middle'}));
 
     // boxes
     for(const k in BOX){const b=BOX[k];
@@ -135,17 +143,17 @@
   function tunnel(){
     const sX=PIPEX, sTop=BOX.server.y+H, sBot=BOX.client.y;
     return [
-      {p:[[sX,sBot],[sX,sTop]], c:'green', cap:'① local이 WS를 <b>outbound로 염</b> — 영속 연결 ↑ (NAT 통과 OK)'},
-      {p:[[BOX.external.x+W,cy(BOX.external)],[BOX.server.x,cy(BOX.server)]], c:'blue', cap:'② 외부 → server.js (공개 HTTPS URL, inbound OK)'},
-      {p:[[sX,sTop],[sX,sBot]], c:'amber', cap:'③ server.js → client.js — <span class="rev">같은 WS 위로 거꾸로 ↓ (역방향)</span>'},
-      {p:[[BOX.client.x,cy(BOX.client)],[BOX.localhost.x+W,cy(BOX.localhost)]], c:'blue', cap:'④ client.js → localhost:3000 (실제 요청/응답)'},
-      {p:[[sX,sBot],[sX,sTop]], c:'green', cap:'⑤ 응답을 같은 WS로 역순 반환 → server.js가 <b>id로 매칭</b> → 외부'},
+      {p:[[sX,sBot],[sX,sTop]], c:'green', cap:'① <b>내 컴퓨터가 먼저</b> 연결을 연다 — 나가는 방향이라 막히지 않는다'},
+      {p:[[BOX.external.x+W,cy(BOX.external)],[BOX.server.x,cy(BOX.server)]], c:'blue', cap:'② 외부 요청이 <b>Sandbox의 공개 주소</b>로 들어온다'},
+      {p:[[sX,sTop],[sX,sBot]], c:'amber', cap:'③ <span class="rev">아까 열어둔 그 연결에 대고 거꾸로 내려보낸다</span>'},
+      {p:[[BOX.client.x,cy(BOX.client)],[BOX.localhost.x+W,cy(BOX.localhost)]], c:'blue', cap:'④ 내 컴퓨터가 <b>진짜 로컬 서버</b>에 전달한다'},
+      {p:[[sX,sBot],[sX,sTop]], c:'green', cap:'⑤ 답은 같은 연결로 되돌아가고, <b>번호표</b>로 짝을 찾아 외부에 전달한다'},
     ];
   }
   function direct(){
     return [
       {p:[[cx(BOX.external),BOX.external.y+H],[cx(BOX.external),NATY]], c:'red', block:true,
-       cap:'외부 → localhost 직접 시도 → <b style="color:#f87171">NAT inbound 차단 ✗</b> (그래서 역방향이 필요)'},
+       cap:'밖에서 내 컴퓨터로 <b style="color:#f87171">직접 들어오려 하면 막힌다</b> — 번호 없는 전화기다'},
     ];
   }
   const steps=()=>mode==='tunnel'?tunnel():direct();
@@ -174,7 +182,7 @@
     const pipeUp = mode==='tunnel' && i>=1;
     $('pipe').classList.toggle('up',pipeUp);
     $('pipelbl').classList.toggle('up',pipeUp);
-    $('pipelbl').textContent = pipeUp ? 'WS ✓ 영속 (local→공개)' : 'WS';
+    $('pipelbl').textContent = pipeUp ? 'WS — 끊지 않고 유지' : 'WS';
     // NAT block
     const blocked = !!(cur&&cur.block);
     $('natline').classList.toggle('block',blocked);
@@ -192,8 +200,8 @@
       act.setAttribute('stroke','none'); act.removeAttribute('marker-end');
       dot.setAttribute('opacity','0');
       $('cap').innerHTML = mode==='tunnel'
-        ? 'localhost는 inbound를 못 받는다(NAT). ▶로 WS가 어떻게 깔리고 요청이 거꾸로 흐르는지 보세요.'
-        : '터널 없이 외부가 localhost에 직접 닿으려 하면? ▶';
+        ? '내 컴퓨터는 밖에서 못 들어온다. ▶로 연결이 어떻게 깔리고 요청이 거꾸로 흐르는지 보세요.'
+        : '터널 없이 밖에서 내 컴퓨터에 직접 닿으려 하면? ▶';
     }
     $('step').disabled=i>=s.length;
     $('step').textContent=i>=s.length?'완료':(i===0?'▶ 단계':'▶ 다음');

--- a/src/content/memo/552.mdx
+++ b/src/content/memo/552.mdx
@@ -1,71 +1,77 @@
 ---
-type: snippet
+type: note
+kind: Explainer
 tags: ['tunneling', 'websocket', 'vercel-sandbox', 'networking']
 status: release
 ctime: 2026-06-07
-mtime: 2026-07-27
-title: vgrok - 터널링의 핵심은 역방향 영속 연결
+mtime: 2026-08-21
+title: vgrok — ngrok과 다른 두 가지
+generated: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+verified: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+sources:
+  - id: vgrok
+    resource: https://github.com/styfle/vgrok
+    title: "vgrok — styfle"
+  - id: ngrok-tcp
+    resource: https://ngrok.com/docs/universal-gateway/tcp/
+    title: "ngrok — TCP endpoints"
+  - id: vercel-sandbox-pricing
+    resource: https://vercel.com/docs/sandbox/pricing
+    title: "Vercel Sandbox — pricing and limits"
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
 
-localhost는 inbound 연결을 못 받는다(NAT/방화벽 뒤). 터널링의 원리는 **공개 머신에서 로컬로 향하는 영속 연결을 미리 깔아두고, 외부 요청을 그 연결 위로 거꾸로 흘려보내는 것**.
+내 컴퓨터에서 서버를 띄워도 밖에서는 못 들어온다. **전화기는 있는데 번호가 없는 것과 같다** — 내가 거는 건 되는데 남이 나에게 걸 수는 없다(NAT·방화벽 뒤라서).
 
-vgrok에서 그 영속 연결은 WebSocket이다. local → sandbox 방향으로 한 번 열어두면, sandbox로 들어온 HTTP 요청을 같은 소켓에 실어 local로 되돌릴 수 있다.
+터널링의 요령은 이 비대칭을 뒤집는 것이다. **내가 먼저 밖으로 걸어놓고 끊지 않는다.** 번호가 공개된 쪽이 그 통화를 붙들고 있다가, 자기한테 온 요청을 그 통화에 대고 흘려보낸다.
 
 ```
-외부 요청 ──HTTP──▶ [공개 머신] server.js ──┐
-                                          │ WebSocket (local이 미리 연결해둠)
-                          localhost ◀──HTTP── [local] client.js ◀──┘
+외부 요청 ──HTTP──▶ [공개 머신] ──┐
+                                │ WebSocket (내 컴퓨터가 먼저 걸어둔 것)
+              내 컴퓨터 ◀──HTTP──┘
 ```
 
 <AutoIframe
   src="/iframe/vgrok-reverse-tunnel.html"
-  title="vgrok 역방향 터널 — 직접(NAT 차단) vs 터널(local이 outbound WS를 깔고 외부 요청을 거꾸로 흘림) 단계별 비교"
+  title="직접 연결은 밖에서 못 들어와 막히고, 터널은 내 컴퓨터가 먼저 연 연결 위로 요청이 거꾸로 흐르는 것을 단계별로 비교"
 />
 
-## 요청/응답 매칭
+**여기까지는 ngrok도 같다.** vgrok이 다른 건 둘이다.
 
-WebSocket은 하나인데 동시 요청은 여럿. 그래서 요청마다 UUID를 붙이고, 공개 머신 쪽에서 `Map<id, res>`로 응답 객체를 들고 있다가 돌아온 메시지의 id로 짝을 찾는다.
+## 하나 — 공개 머신을 빌린다
 
-```javascript
-// [server] 외부 요청 수신 → 보류 + 전달
-const id = randomUUID()
-responses.set(id, res)
-client.send(JSON.stringify({ id, method, url, headers, body }))
+ngrok은 그 "번호가 공개된 쪽"을 자기 인프라로 굴린다. vgrok은 **잠깐 빌리는 컴퓨터(Vercel Sandbox)를 그 자리에 끼워넣는다.** 마침 필요한 두 가지가 다 딸려 오기 때문이다 — **공개 주소가 그냥 나오고**(도메인도 인증서도 설정 0), **코드를 올려 돌릴 수 있다.**
 
-// [server] WS로 응답 돌아오면 id로 원래 res 복원
-const { id, statusCode, headers, body } = JSON.parse(msg)
-responses
-  .get(id)
-  .writeHead(statusCode, headers)
-  .end(Buffer.from(body, 'base64url'))
-```
+그러니 터널 머신은 특별한 물건이 아니다. **"공개 주소가 나오고 코드가 돌면" 무엇이든 된다.** Sandbox는 그걸 가장 싸게 얻는 한 가지 방법일 뿐이다.
 
-body는 base64url — 이미지·파일 같은 바이너리를 JSON에 안전하게 싣기 위함.
+핵심 코드가 **220줄쯤**인 것이 그 증거다 — 네트워킹·보안·HTTPS·DNS를 빌린 쪽이 다 떠안아서 남는 게 이만큼이다.
 
-## Sandbox는 "터널 머신"의 일회용 대체재
+대가는 수명이다. 빌린 거라 오래 못 쓴다 — Hobby는 **한 세션에 45분**.[^vercel-sandbox-pricing] 다만 세션 단위라 멈췄다 이어붙이면 총 수명은 늘릴 수 있다.
 
-여기서 신선한 점: 보통 터널링은 ngrok처럼 **전용 공개 서버**가 필요한데, vgrok은 Vercel Sandbox를 그 자리에 끼워넣는다. Sandbox가 마침 두 가지를 다 주기 때문:
+## 둘 — 바이트가 아니라 메시지를 나른다
 
-- `sandbox.domain(port)` → 즉시 공개 HTTPS URL (도메인/인증서 설정 0)
-- 임의 코드 실행 → WebSocket 프록시(server.js)를 그 위에 배포
+ngrok은 **TCP 터널도** 준다. 바이트를 그대로 흘려보내니 SSH·데이터베이스·MQTT·게임 서버까지 나른다.[^ngrok-tcp]
 
-```typescript
-const sandbox = await Sandbox.create({ runtime: 'node22', ports: [3000] })
-const url = sandbox.domain(3000) // 외부 진입점
-await sandbox.writeFiles([{ path: 'server.js', content }])
-await sandbox.runCommand({ cmd: 'node', args: ['server.js'], detached: true })
-```
+vgrok은 그렇지 않다. HTTP 요청을 **뜯어서** `method`·`url`·`headers`·`body`로 만들고, 반대편에서 다시 조립한다. WebSocket은 끊기지 않는 통로 역할만 하고, 그 위로 흐르는 건 직렬화된 HTTP 메시지다.
 
-즉 "공개 URL + 코드 실행"이 되는 임시 컴퓨팅이라면 무엇이든 터널 머신이 될 수 있고, Sandbox는 그걸 가장 싸게 얻는 한 수단일 뿐.
+이 한 가지 선택에서 나머지가 전부 따라 나온다.
 
-## 한계
+| 그래서 | 왜냐면 |
+|---|---|
+| **번호표를 붙인다** | 통로 하나에 여러 요청·응답을 섞어 싣기 때문. 바이트 터널이면 연결마다 흐름이 따로라 필요 없다 |
+| **바이너리를 글자로 바꾼다** | 메시지를 JSON으로 만드니까. 이미지를 그대로 못 싣는다 |
+| **HTTP만 된다** | HTTP를 뜯어서 나르니까. 뜯을 수 없는 프로토콜은 못 나른다 |
+| **다 모아야 보낸다** | 메시지 한 덩어리로 부치니까. 양쪽 다 `on('data')`로 모았다가 `on('end')`에서 한 번에 넘긴다[^vgrok] |
 
-- Hobby 45분 타임아웃, HTTP만(TCP 터널 X), 단일 클라이언트
-- 핵심 코드 ~220줄 — 네트워킹/보안/HTTPS/DNS를 Sandbox가 다 추상화해서 가능
+이미지·CSS 같은 static 리소스도 특별 취급이 없다. 똑같이 바이트를 글자로 바꿔 실었다 되돌린다. **되긴 되는데 하나씩 통째로 통과한다** — 점진 렌더가 안 되고, 큰 파일은 메모리에 통째로 올라가며, base64라 전송량이 3분의 1쯤 늘어난다. 끝나지 않는 응답(SSE 같은 것)은 아예 못 다룬다.
 
 ---
 
-- [vgrok](https://github.com/styfle/vgrok)
-- [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox)
+그 밖에 클라이언트는 하나만 붙는다.
+
+[^ngrok-tcp]: *"TCP endpoints enable you to deliver any network service with a TCP-based protocol"* — SSH·VNC·RDP, MySQL·Postgres, MQTT, 게임 서버 등. ([ngrok — TCP endpoints](https://ngrok.com/docs/universal-gateway/tcp/))
+
+[^vercel-sandbox-pricing]: 최대 세션 길이는 Hobby 45분 · Pro/Enterprise 24시간. *"The maximum duration applies to a single session, not to the sandbox itself. The limit resets every time a sandbox stops and resumes, so the total lifetime of a persistent sandbox is effectively unbounded."* ([Vercel Sandbox — pricing and limits](https://vercel.com/docs/sandbox/pricing))
+
+[^vgrok]: `server.ts` 는 `req.on('data', chunk => chunks.push(chunk))` 로 모아 `req.on('end')` 에서 `Buffer.concat(chunks).toString('base64url')` 로 부치고, 받는 쪽은 `res.end(Buffer.from(body, 'base64url'))` 로 한 번에 쓴다. `client.ts` 도 응답을 같은 방식으로 모은다. ([vgrok — styfle](https://github.com/styfle/vgrok))


### PR DESCRIPTION
상세 구현보다 원리가 남게 다시 썼다. 구조를 **ngrok 과의 차이**로 잡으니 흩어져 있던 사실들이 두 축에 붙는다.

## 구조

터널링의 요령(*내가 먼저 걸어두고 끊지 않는다*)까지는 **ngrok 도 같다.** 다른 건 둘이다.

| | ngrok | vgrok | 대가 |
|---|---|---|---|
| **하나 — 공개 머신** | 자기 인프라를 굴린다 | **Vercel Sandbox 를 끼워넣는다** (공개 주소 + 코드 실행이 되니까) | 빌린 거라 오래 못 쓴다 — Hobby 한 세션 45분 |
| **둘 — 나르는 단위** | **TCP 터널도** 준다 (SSH·DB·MQTT·게임 서버) | HTTP 를 **뜯어서 JSON 메시지**로 | HTTP 만, 스트리밍 불가 |

전에는 메시지 축이 **기준점 없이 떠 있고** ngrok 은 둘째 축에서만 한 마디 나왔다. `## 한계` 섹션은 없애고 비용을 각 선택 옆에 붙였다.

## 원리 하나가 귀결 넷을 설명한다

*"메시지를 나른다"* 에서 전부 따라 나온다:

| 그래서 | 왜냐면 |
|---|---|
| 번호표를 붙인다 | 통로 하나에 여러 요청을 섞어 실으니 |
| 바이너리를 글자로 | JSON 이니 |
| HTTP 만 된다 | 뜯어야 하니 |
| **다 모아야 보낸다** | 메시지 한 덩어리로 부치니 |

마지막은 **소스로 확인**했다 — `server.ts`·`client.ts` 둘 다 `on('data')` 로 모아 `on('end')` 에서 한 번에 부친다. 그래서 static 리소스가 *"되긴 되는데 통째로 통과"* 한다: 점진 렌더 없음, 큰 파일은 메모리에, base64 라 전송량 33% 증가, SSE 같은 끝나지 않는 응답은 불가.

## 초등학생 눈높이

```
전 : localhost는 inbound 연결을 못 받는다(NAT/방화벽 뒤)
후 : 전화기는 있는데 번호가 없는 것과 같다
```

`randomUUID`·`base64url`·Sandbox API 코드 블록은 뺐다 — **상하기 쉬운 부분**이기도 하다(Sandbox 문서는 이미 canonical URL 이 `/docs/sandbox` 로 옮겼고 persistent sandboxes 가 기본이 됐다).

`45분` 은 여전히 맞지만 문서에 새 단서가 생겼다: *"The maximum duration applies to a single **session** … the total lifetime of a persistent sandbox is effectively unbounded."*

## 다이어그램

`server.js` 가 **빌린 컴퓨터 안에서 돈다**는 게 안 보였다. Vercel Sandbox 를 점선 컨테이너로 그려 감쌌다.

라벨·캡션도 메모 말투로: `outbound`/`inbound`/`역방향` → *나가는 방향*/*들어오는 건*/*거꾸로*. 마지막 캡션이 메모의 비유로 이어진다 — *"직접 들어오려 하면 막힌다 — 번호 없는 전화기다"*.

> 컨테이너 하단 라벨이 WS 파이프와 `x` 좌표가 겹쳐서 상자 위로 올렸다. JS 문법·좌표 검증은 스크립트로 확인했지만 **브라우저 시각 확인은 못 했다.**

## 검증

- `pnpm lint:memo` — 540개, 오류 0 · 경고 0
- `astro build` — 785페이지
- `type: snippet` → `note`, `kind: Explainer` · `generated` · `verified` · `sources` 3건(vgrok · ngrok TCP · Sandbox pricing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
