### PR TITLE
memo: 551 주의 첫 항목 축약

### DIFF
--- a/src/content/memo/551.md
+++ b/src/content/memo/551.md
@@ -5,7 +5,7 @@ tags: ['dnd-kit', 'tanstack-query', 'optimistic-update', 'race-condition', 'reac
 status: release
 ctime: 2026-06-07
 mtime: 2026-08-21
-generated: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
+generated: { by: claude/opus-5, at: 2026-08-21T01:00:00Z }
 verified: { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
 sources:
   - id: dnd-kit-833
@@ -70,7 +70,7 @@ function SortableList() {
 
 주의:
 
-- **invalidate race** — `isReorderingRef` 없으면 mutation 직후 refetch가 옛 순서를 들고 와 `useEffect`가 local을 덮는다(또 다른 튕김). 더 깔끔한 변형: `mutationFn`이 새 순서를 반환하게 하고 `onSuccess`에서 `setItems(data)`, invalidate는 제거.
+- **invalidate race** — `isReorderingRef` 없으면 mutation 직후 refetch가 옛 순서를 들고 와 `useEffect`가 local을 덮는다(또 다른 튕김). 서버가 새 순서를 반환한다면 `onSuccess`에서 바로 받아 이 가드를 통째로 없앨 수 있다.
 - **stable id** — `SortableContext`·자식 `key`·`useSortable({ id })`가 전부 같은 id여야 한다. 인덱스를 key로 쓰지 않는다.
 - **`DragOverlay` 잔여 튕김** — `dropAnimation={null}`로 없앨 수 있다. 진단도 겸한다: 이걸로 사라지면 위 원인이 맞다.
 


### PR DESCRIPTION
본문 코드를 다 읽힌 뒤에 *"사실 더 깔끔한 변형이 있다"*며 **대안 구현을 설명**하고 있었다. 읽는 순서가 어색하고, 무엇보다 두 방법은 **전제가 다르다.**

| | 본문 코드 | 대안 |
|---|---|---|
| 동기화 | invalidate → refetch | `mutationFn` 반환값을 그대로 |
| 필요한 것 | `isReorderingRef` + `useEffect` 가드 | 없음 |
| **전제** | 없음 | **서버가 새 순서를 반환해야** |

전제가 다르니 한쪽이 일방적으로 낫지 않다. 본문 코드는 서버 API 를 못 고치는 상황에서도 돌아가는 쪽이라 그대로 두고, 대안은 **"존재한다"까지만** 남긴다.

```diff
- 더 깔끔한 변형: `mutationFn`이 새 순서를 반환하게 하고
-                `onSuccess`에서 `setItems(data)`, invalidate는 제거.
+ 서버가 새 순서를 반환한다면 `onSuccess`에서 바로 받아 이 가드를
+ 통째로 없앨 수 있다.
```

## 검증

- `pnpm lint:memo` — 540개, 오류 0 · 경고 0
- `astro build` — 785페이지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
