### PR TITLE
memo: 555 를 라우터 관점으로 — blocker 를 균일하게 못 만드는 이유

### DIFF
--- a/public/iframe/traverse-rollback-explorer.html
+++ b/public/iframe/traverse-rollback-explorer.html
@@ -33,6 +33,10 @@
   .cell.moved .u{color:var(--red)}
   .cell.rolled{border-color:var(--green);background:var(--green-bg)}
   .cell.rolled .u{color:var(--green)}
+  .cell.kept{border-color:var(--green);background:var(--green-bg)}
+  .cell.kept .u{color:var(--green)}
+  .cell.changed{border-color:var(--amber);background:#2a2207}
+  .cell.changed .u{color:var(--amber)}
   .idxline{font-family:var(--font-mono);font-size:11px;color:var(--dim);margin:0 0 12px;text-align:center}
   .idxline b{color:var(--text)}
 
@@ -40,7 +44,9 @@
   button{font-family:inherit;font-size:12.5px;padding:7px 11px;border:1px solid var(--border2);border-radius:var(--radius);background:var(--panel2);color:var(--text);cursor:pointer}
   button:hover:not(:disabled){background:#222a3a}
   button:disabled{opacity:.4;cursor:default}
+  .ty2{font-family:var(--font-mono);font-size:10.5px;color:var(--dim);margin-left:3px}
   button.trav{border-color:var(--blue-bd);color:var(--blue)}
+  button.trav.edge{border-color:var(--border2);color:var(--dim)}
   .blk{margin-left:auto;font-family:var(--font-mono);font-size:12px;padding:6px 11px;border-radius:999px;border:1px solid var(--border2);background:var(--panel2);color:var(--dim);cursor:pointer}
   .blk.on{border-color:var(--red-bd);background:var(--red-bg);color:var(--red)}
 
@@ -60,18 +66,18 @@
 <body>
 <div class="wrap">
 <h1>traverse rollback explorer</h1>
-<p class="sub">블로커를 켜고 눌러보세요 — push·replace·reload는 preventDefault로 안 움직이고, traverse(◀▶)만 움직였다 되돌아온다</p>
-<h2 class="sr-only">Navigation API의 네 nav 타입을 블로커가 켜진 상태에서 실행하며, traverse만 사전 취소가 불가해 사후 롤백(go(-delta))으로 처리됨을 히스토리 리스트+커서로 보여주는 explorer.</h2>
+<p class="sub">버튼은 <b>떠나려는 시도</b>이고, 회색 글자는 그 시도의 종류입니다. 다섯 가지 모두 같은 <code>navigate</code> 이벤트로 모입니다 — 블로커를 켜고 눌러보세요. 넷은 아예 안 움직이고 뒤로·앞으로만 <b>움직였다 되돌아옵니다.</b> 끝에서 누르면 범위 밖이라 아무 일도 없다는 것도 보입니다</p>
+<h2 class="sr-only">히스토리를 리스트와 커서로 그려놓고 네 가지 이동을 실행해 본다. 블로커를 켜면 push·replace·reload 는 사전에 취소돼 커서가 안 움직이고, 뒤로·앞으로만 먼저 움직였다가 go(-delta) 로 되돌아온다. 리스트 끝에서 누르면 범위 밖이라 아무 일도 일어나지 않는 것까지 확인할 수 있다.</h2>
 
 <div class="tape" id="tape" role="img" aria-label="히스토리 엔트리 리스트와 현재 커서"></div>
 <div class="idxline" id="idx"></div>
 
 <div class="controls">
-  <button data-nav="push">push</button>
-  <button data-nav="replace">replace</button>
-  <button data-nav="reload">reload</button>
-  <button class="trav" data-nav="back" id="back">◀ back</button>
-  <button class="trav" data-nav="forward" id="fwd">forward ▶</button>
+  <button data-nav="push">새 페이지로 <span class="ty2">push</span></button>
+  <button data-nav="replace">주소만 교체 <span class="ty2">replace</span></button>
+  <button data-nav="reload">새로고침 <span class="ty2">reload</span></button>
+  <button class="trav" data-nav="back" id="back">◀ 뒤로 <span class="ty2">traverse</span></button>
+  <button class="trav" data-nav="forward" id="fwd">앞으로 ▶ <span class="ty2">traverse</span></button>
   <span class="blk" id="blk" role="button" tabindex="0" aria-pressed="false">blocker: off</span>
 </div>
 
@@ -107,8 +113,10 @@
       tape.appendChild(c);
     });
     $('idx').innerHTML=`idx = <b>${idx}</b> / ${entries.length-1}　·　현재 <b>${entries[idx].u}</b>`;
-    $('back').disabled=busy||idx<=0;
-    $('fwd').disabled=busy||idx>=entries.length-1;
+    $('back').disabled=busy;
+    $('fwd').disabled=busy;
+    $('back').classList.toggle('edge', idx<=0);
+    $('fwd').classList.toggle('edge', idx>=entries.length-1);
     document.querySelectorAll('[data-nav]').forEach(b=>{ if(b.dataset.nav==='push'||b.dataset.nav==='replace'||b.dataset.nav==='reload') b.disabled=busy; });
     $('blk').classList.toggle('on',blocker);
     $('blk').textContent='blocker: '+(blocker?'on':'off');
@@ -123,23 +131,34 @@
     $('log').scrollTop=$('log').scrollHeight;
   }
 
+  function flash(i,cls,ms){ render({i,cls}); setTimeout(render, ms||700); }
+
   // push/replace/reload — 사전 취소 가능
   function cancellableNav(type){
     if(blocker){
-      log(`navigate <b>${type}</b> · cancellable ✓ · <span class="green">preventDefault()</span> → 차단 (이동 없음)`,'');
+      log(`navigate <b>${type}</b> · 취소 가능 ✓ · <span class="green">preventDefault()</span> → 차단. <b>커서도 리스트도 그대로</b>`,'');
+      flash(idx,'kept');
       return;
     }
-    if(type==='push'){ entries=entries.slice(0,idx+1); entries.push({u:'/n'+key,k:key}); key++; idx=entries.length-1; }
-    else if(type==='replace'){ entries[idx]={u:entries[idx].u+'~',k:entries[idx].k}; }
-    // reload: 상태 변화 없음
-    log(`navigate <b>${type}</b> · 적용 → idx=${idx} (${entries[idx].u})`,'blue');
-    render();
+    if(type==='push'){
+      entries=entries.slice(0,idx+1); entries.push({u:'/n'+key,k:key}); key++; idx=entries.length-1;
+      log(`navigate <b>push</b> · 적용 → 항목이 하나 늘고 커서가 끝으로 (idx=${idx}, ${entries[idx].u})`,'blue');
+    } else if(type==='replace'){
+      entries[idx]={u:entries[idx].u+'~',k:key++};
+      log(`navigate <b>replace</b> · 적용 → 커서는 그대로, <b>그 자리 항목만</b> 바뀐다 (${entries[idx].u})`,'blue');
+    } else {
+      log(`navigate <b>reload</b> · 적용 → 문서만 다시 불러온다. <b>리스트도 커서도 안 바뀐다</b>`,'blue');
+    }
+    flash(idx,'changed');
   }
 
   // traverse — 사전 취소 불가 → 사후 롤백
   function traverse(delta){
     const from=idx, to=idx+delta;
-    if(to<0||to>=entries.length) return;
+    if(to<0||to>=entries.length){
+      log(`<span class="dim">go(${delta}) · 리스트 밖(idx=${from} → ${to}) — <b>아무 일도 안 일어난다.</b> navigate 이벤트도 안 뜨니 되돌릴 것도 없다</span>`,'');
+      return;
+    }
     if(!blocker){
       idx=to; log(`navigate <b>traverse</b> · 적용 → idx=${from}→${to} (${entries[idx].u})`,'blue'); render(); return;
     }
@@ -151,7 +170,7 @@
     setTimeout(()=>{
       idx=from;                       // go(-delta) 롤백
       busy=false;
-      log(`<span class="amber">go(${-delta})</span> 롤백 → idx=${to}→${from} · 관측상 항등 (떴다 사라진 두 프레임)`,'green');
+      log(`<span class="amber">go(${-delta})</span> 롤백 → idx=${to}→${from} · 겉보기엔 아무 일도 없었던 것처럼 (떴다 사라진 두 프레임)`,'green');
       render({i:from, cls:'rolled'});
       setTimeout(render,450);
     },750);

--- a/src/content/memo/555.mdx
+++ b/src/content/memo/555.mdx
@@ -4,33 +4,60 @@ kind: Explainer
 tags: ['navigation-api', 'router']
 status: release
 ctime: 2026-06-15
-mtime: 2026-08-19
-generated: { by: claude/opus-5, at: 2026-08-19T12:30:00Z }
+mtime: 2026-08-21
+generated: { by: claude/opus-5, at: 2026-08-21T03:00:00Z }
+verified: { by: claude/opus-5, at: 2026-08-21T03:00:00Z }
+sources:
+  - id: mdn-navigation-destination
+    resource: https://developer.mozilla.org/en-US/docs/Web/API/NavigationDestination/index
+    title: "NavigationDestination.index — MDN"
+  - id: chrome-navigation-api
+    resource: https://developer.chrome.com/docs/web-platform/navigation-api
+    title: "Navigation API — Chrome for Developers"
 ---
 
 import AutoIframe from '@components/AutoIframe/AutoIframe.astro'
 
-Navigation API에서 `traverse`(뒤/앞 이동)만 `preventDefault()`로 막을 수 없다. push·replace·reload는 취소 가능, traverse는 취소 정의역 밖.
+Navigation API로 라우터를 만들어보면 `navigate` 이벤트가 반갑다. 링크 클릭·폼 제출·프로그램 호출은 물론 `history.pushState()`까지 **떠나는 모든 경로가 여기 하나로 모인다.** 라우터가 잡아야 할 걸 한 자리에서 잡는다.
 
-그래서 traverse blocker는 *사전 차단*이 아니라 *사후 롤백*이다 — 이동은 이미 일어났으니 되돌린다:
+그런데 라우터가 흔히 내주는 기능 하나에서 막힌다 — **이탈 방지**(저장 안 된 폼에서 "정말 나가시겠습니까"). `preventDefault()`가 있으니 될 것 같은데, `push`·`replace`·`reload`는 되고 **뒤로·앞으로(`traverse`)만 안 된다.**
+
+그리고 이건 빠뜨린 게 아니라 **일부러 그렇게 만든 것**이다.[^chrome-navigation-api]
+
+> 사용자가 브라우저의 뒤로·앞으로 버튼을 누르는 경우엔 `preventDefault()`로 취소할 수 없다 — **사용자를 사이트에 가둘 수 있으면 안 되기 때문이다.**
+
+## 그래서 라우터 안에 경로가 둘 생긴다
+
+셋은 **사전 차단**, 뒤로·앞으로는 이미 움직였으니 **사후 롤백**이다.
+
+블로커가 켜져 있을 때:
 
 ```js
-// traverse가 이미 go(n)을 일으킴 → blocker는 go(-n)으로 원위치
 onNavigate(e) {
-  if (blocked) history.go(-delta) // 관측상 항등 ("리스트 + 커서" 모델이라)
+  if (e.navigationType !== 'traverse') return e.preventDefault()   // 아예 안 움직임
+  history.go(navigation.currentEntry.index - e.destination.index)  // 일어난 뒤 되돌림
 }
 ```
 
-정의역 조건(`0 ≤ idx + n`) 안에서만 항등 — `go n` 다음 `go (-n)`이 원위치.
+되돌릴 거리는 API가 준다 — `destination.index`가 목적지 커서고, 지금 커서와의 차이가 곧 이동량이다.
+
+**그런데 그 `index`는 `traverse`일 때만 값이 있다. 나머지 셋에서는 `-1`이다.**[^mdn-navigation-destination] 라우터가 억지로 나눈 게 아니라 **API 자체가 같은 선을 긋고 있다.** blocker 하나를 균일하게 못 만들고, 라이브러리 안에서 두 갈래를 계속 들고 가야 한다.
+
+## 롤백이 정말 제자리인가
+
+history를 **리스트 + 커서**로 보면 그렇다. `go(n)`은 리스트를 건드리지 않고 **커서만** 옮긴다. 그러니 `go(n)` 다음 `go(-n)`은 커서를 원래 자리로 돌려놓는다 — 겉보기엔 아무 일도 없었던 것처럼 된다.
+
+단 **범위 안에서만** 그렇다. `0 ≤ idx + n`을 벗어나는 `go`는 아무 일도 하지 않는다 — 그러니 일어나지도 않은 이동을 되돌리면 오히려 진짜로 움직인다. 이 패턴에선 그럴 일이 없지만(이동이 없으면 `navigate` 이벤트도 안 뜨니 롤백을 부를 일이 없다), 등식이 무조건 성립하는 건 아니다.
 
 <AutoIframe
   src="/iframe/traverse-rollback-explorer.html"
-  title="traverse rollback explorer — 블로커를 켜면 push·replace·reload는 안 움직이고 traverse만 움직였다 go(-delta)로 되돌아온다"
+  title="블로커를 켠 채 다섯 가지 이동을 시도해, 넷은 아예 안 움직이고 뒤로·앞으로만 움직였다 되돌아오는 것을 히스토리 리스트와 커서로 보여준다"
 />
 
 ---
 
-곁가지 (같은 list+cursor 모델의 다른 비대칭):
+우회라는 건 알고 쓰는 게 좋다. 브라우저가 사용자를 위해 막아둔 걸 되돌리는 것이라, 정말 붙잡아야 할 때만 쓴다.
 
-- navigationType에서 `reload`·`traverse`가 **같은 POP**으로 뭉개짐(정보 손실) → idx 변화량 `delta`로 구분.
-- 내부 호출이 쏜 navigate 이벤트는 `info` 태그로 흡수 → 재진입 종료.
+[^chrome-navigation-api]: *"it will fire for all types of navigations, whether the user performed an action (such as clicking a link, submitting a form, or going back and forward) or when navigation is triggered programmatically"* / *"you can't cancel a navigation via `preventDefault()` if the user is pressing the Back or Forward buttons in their browser; **you should not be able to trap your users on your site**."* ([Navigation API — Chrome for Developers](https://developer.chrome.com/docs/web-platform/navigation-api))
+
+[^mdn-navigation-destination]: *"Returns the `index` value of the destination `NavigationHistoryEntry` if the `NavigateEvent.navigationType` is `traverse`, or **`-1` otherwise**."* ([NavigationDestination.index — MDN](https://developer.mozilla.org/en-US/docs/Web/API/NavigationDestination/index))


### PR DESCRIPTION
**주어가 없었다.** *"traverse 만 `preventDefault()` 로 막을 수 없다"* 로 시작하는데 **무엇을 하다 막혔는지**가 빠져 있어 `blocker` 라는 말이 문맥 없이 나왔다. `tags` 는 이미 `router` 를 달고 있는데 본문이 그걸 한 번도 안 다뤘다(#38 의 `574` 와 같은 패턴).

## 라우터를 만들다 만난 한계

Navigation API 로 라우터를 만들면 `navigate` 이벤트가 반갑다 — 링크 클릭·폼 제출·프로그램 호출은 물론 `history.pushState()` 까지 **떠나는 모든 경로가 여기 하나로 모인다.** 그런데 라우터가 흔히 내주는 **이탈 방지**에서 막힌다.

막히는 게 버그가 아니라 **의도**다:

> *"you should not be able to trap your users on your site"*

규칙을 다시 말한 *"취소 정의역 밖"* 대신 **이유**를 적었다.

## 증거를 둘로

| | 근거 |
|---|---|
| `preventDefault()` 가 traverse 에만 안 통한다 | Chrome 문서 |
| **`destination.index` 가 traverse 일 때만 값이고 나머지는 `-1`** | MDN |

두 번째가 새로 찾은 것이다. **라우터가 억지로 나눈 게 아니라 API 자체가 같은 선을 긋고 있다**는 뜻이라, *"두 갈래를 들고 가야 한다"* 가 주장에서 **관찰**이 된다.

덤으로 `delta` 의 출처도 여기서 나온다:

```diff
- history.go(-delta)                                             // delta 는 어디서?
+ history.go(navigation.currentEntry.index - e.destination.index)
```

## 덜어낸 것

여섯 번에 걸쳐 하나씩 얹다 보니 **한 메모가 열 가지를 말하게** 됐다. 개별로는 정당했는데 합이 빡빡하다.

`POP 뭉개짐`·`info 재진입` 을 뺐다 — blocker 와 **다른 주제**이고, 라우터를 만들며 만난 다른 불편일 뿐이다. 나중에 형제 메모로 세울 만하다. **4399자 → 3715자.**

경계 조건 문장도 정정했다. *"되돌리는 `go` 가 짝을 잃는다"* 는 실무 버그처럼 읽혔는데, 이 패턴에선 이동이 없으면 `navigate` 이벤트도 안 떠서 안 터진다.

## 데모

- **리스트 끝에서도 누를 수 있게** 했다. 전에는 버튼이 잠겨 있어 **증명의 경계 조건을 볼 수 없었다**
- **차단에 시각 피드백이 없었다.** traverse 만 빨강→초록 애니메이션이 있고 `push` 를 막으면 로그 한 줄뿐이라 *"눌렀는데 반응이 없다"* 로 읽혔다 → 차단·롤백은 초록, 변경은 노랑
- **버튼 이름이 `history.pushState()` 호출처럼 읽혔다** → *"새 페이지로 `push`"* 처럼 시도하는 일을 앞에, 종류를 회색으로 뒤에
- 라우터 어휘 줄(`PUSH`/`REPLACE`/`POP`/`POP`)은 넣었다가 **뺐다** — 본문에서 POP 뭉개짐을 덜어냈으므로 데모만 남으면 잔여물이다

## 검증

- `pnpm lint:memo` — 540개, 오류 0 · 경고 0
- `astro build` — 785페이지
- 데모 JS 문법·잔여 검사 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
